### PR TITLE
Add basic card and blackjack table scenes

### DIFF
--- a/assets/placeholder.svg
+++ b/assets/placeholder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#cccccc"/>
+  <circle cx="32" cy="32" r="20" fill="#888888"/>
+</svg>

--- a/project.godot
+++ b/project.godot
@@ -1,0 +1,10 @@
+; Engine configuration file.
+
+config_version=5
+
+[application]
+config/name="Fortune Realms"
+run/main_scene="res://scenes/card_table.tscn"
+
+[rendering]
+renderer="forward_plus"

--- a/scenes/card.tscn
+++ b/scenes/card.tscn
@@ -1,0 +1,22 @@
+[gd_scene load_steps=3 format=4]
+
+[node name="Card" type="Control"]
+custom_minimum_size = Vector2(80, 120)
+script = preload("res://scripts/card.gd")
+
+[node name="Background" type="ColorRect" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+color = Color(1, 1, 1)
+
+[node name="Icon" type="TextureRect" parent="."]
+texture = preload("res://assets/placeholder.svg")
+position = Vector2(10, 10)
+size = Vector2(40, 40)
+
+[node name="Label" type="Label" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+horizontal_alignment = 1
+vertical_alignment = 1
+text = "1"

--- a/scenes/card_table.tscn
+++ b/scenes/card_table.tscn
@@ -1,0 +1,23 @@
+[gd_scene load_steps=4 format=4]
+
+[node name="CardTable" type="Control"]
+script = preload("res://scripts/card_table.gd")
+
+[node name="DrawButton" type="Button" parent="."]
+text = "Draw"
+position = Vector2(20, 20)
+
+[node name="HoldButton" type="Button" parent="."]
+text = "Hold"
+position = Vector2(120, 20)
+
+[node name="ScoreLabel" type="Label" parent="."]
+text = "Score: 0"
+position = Vector2(220, 25)
+
+[node name="CardsContainer" type="Node2D" parent="."]
+position = Vector2(20, 80)
+
+[node name="AceMenu" type="PopupMenu" parent="."]
+
+[node name="StarMenu" type="PopupMenu" parent="."]

--- a/scripts/card.gd
+++ b/scripts/card.gd
@@ -1,0 +1,7 @@
+extends Control
+
+var value := ""
+
+func set_value(v):
+    value = str(v)
+    $Label.text = value

--- a/scripts/card_table.gd
+++ b/scripts/card_table.gd
@@ -1,0 +1,52 @@
+extends Control
+
+var card_scene := preload("res://scenes/card.tscn")
+var total_score := 0
+var cards := []
+var current_card: Control
+
+func _ready():
+    randomize()
+    $DrawButton.pressed.connect(_on_draw_pressed)
+    $HoldButton.pressed.connect(_on_hold_pressed)
+    $AceMenu.id_pressed.connect(_on_ace_selected)
+    $StarMenu.id_pressed.connect(_on_star_selected)
+    $ScoreLabel.text = "Score: 0"
+    $AceMenu.add_item("1", 1)
+    $AceMenu.add_item("10", 10)
+    for i in range(1, 11):
+        $StarMenu.add_item(str(i), i)
+
+func _on_draw_pressed():
+    var values = [1,2,3,4,5,6,7,8,9,10,"A","Star"]
+    var choice = values[randi() % values.size()]
+    var card = card_scene.instantiate()
+    $CardsContainer.add_child(card)
+    card.position = Vector2(cards.size() * 60, 0)
+    cards.append(card)
+    card.set_value(choice)
+    if choice == "A":
+        current_card = card
+        $AceMenu.popup()
+    elif choice == "Star":
+        current_card = card
+        $StarMenu.popup()
+    else:
+        total_score += int(choice)
+        _update_score()
+
+func _on_ace_selected(id):
+    current_card.set_value(id)
+    total_score += id
+    _update_score()
+
+func _on_star_selected(id):
+    current_card.set_value(id)
+    total_score += id
+    _update_score()
+
+func _on_hold_pressed():
+    $DrawButton.disabled = true
+
+func _update_score():
+    $ScoreLabel.text = "Score: %d" % total_score


### PR DESCRIPTION
## Summary
- Set up Godot 4 project with placeholder icon
- Implement Card scene with white background, number label, and icon
- Implement CardTable scene with draw/hold buttons, score label, and selectable special cards

## Testing
- `godot --version` *(fails: command not found)*
- `godot4 --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b14a620688832d8fd2f5e4aca65560