### PR TITLE
Refactor card scene to use external resources

### DIFF
--- a/scenes/card.tscn
+++ b/scenes/card.tscn
@@ -1,8 +1,11 @@
 [gd_scene load_steps=3 format=4]
 
+[ext_resource path="res://scripts/card.gd" type="Script" id=1]
+[ext_resource path="res://assets/placeholder.svg" type="Texture2D" id=2]
+
 [node name="Card" type="Control"]
 custom_minimum_size = Vector2(80, 120)
-script = preload("res://scripts/card.gd")
+script = ExtResource("1")
 
 [node name="Background" type="ColorRect" parent="."]
 anchor_right = 1.0
@@ -10,7 +13,7 @@ anchor_bottom = 1.0
 color = Color(1, 1, 1)
 
 [node name="Icon" type="TextureRect" parent="."]
-texture = preload("res://assets/placeholder.svg")
+texture = ExtResource("2")
 position = Vector2(10, 10)
 size = Vector2(40, 40)
 


### PR DESCRIPTION
## Summary
- load card script and placeholder texture via ext_resource references

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b14cd7f8e8832d920c101a829aa959