### PR TITLE
refactor: use ext resource for card table script

### DIFF
--- a/scenes/card_table.tscn
+++ b/scenes/card_table.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=4 format=4]
+[gd_scene load_steps=2 format=4]
+[ext_resource path="res://scripts/card_table.gd" type="Script" id=1]
 
 [node name="CardTable" type="Control"]
-script = preload("res://scripts/card_table.gd")
+script = ExtResource("1")
 
 [node name="DrawButton" type="Button" parent="."]
 text = "Draw"


### PR DESCRIPTION
## Summary
- reference CardTable script as external resource
- update load steps for new resource

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b14ceabc64832d9b0ca9f177df34ed