### PR TITLE
Specify card_scene type

### DIFF
--- a/scripts/card_table.gd
+++ b/scripts/card_table.gd
@@ -1,6 +1,6 @@
 extends Control
 
-var card_scene := preload("res://scenes/card.tscn")
+var card_scene: PackedScene = preload("res://scenes/card.tscn")
 var total_score := 0
 var cards := []
 var current_card: Control


### PR DESCRIPTION
## Summary
- specify PackedScene type for `card_scene`

## Testing
- `godot --check-only` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b14f778608832db20a58abfb761772