### PR TITLE
Add number label and textures for cards

### DIFF
--- a/scenes/Card.gd
+++ b/scenes/Card.gd
@@ -1,7 +1,31 @@
 extends Control
 
+const CARD_TEXTURES: Dictionary = {
+    1: preload("res://assets/cards_png/Tarot Cats/1. The Magician.png"),
+    2: preload("res://assets/cards_png/Tarot Cats/2. The Priestess.png"),
+    3: preload("res://assets/cards_png/Tarot Cats/3. The Empress.png"),
+    4: preload("res://assets/cards_png/Tarot Cats/4. The Emperor.png"),
+    5: preload("res://assets/cards_png/Tarot Cats/5. The Hierophant.png"),
+    6: preload("res://assets/cards_png/Tarot Cats/6. The Lovers.png"),
+}
+
 var mouse_in: bool = false
 var is_dragging: bool = false
+var value := ""
+
+func set_number(num: int) -> void:
+        $NumberLabel.text = str(num)
+        var tex: Texture2D = CARD_TEXTURES.get(num, null)
+        if tex:
+                $Sprite2D.texture = tex
+                $Sprite2D/Shadow.texture = tex
+
+func set_value(v):
+        value = str(v)
+        if typeof(v) == TYPE_INT:
+                set_number(v)
+        else:
+                $NumberLabel.text = value
 
 func _physics_process(delta: float) -> void:
 	drag_logic(delta)

--- a/scenes/card.tscn
+++ b/scenes/card.tscn
@@ -23,5 +23,12 @@ position = Vector2(1.49991, -0.00012207)
 scale = Vector2(1.0018, 1)
 texture = ExtResource("1_d81rb")
 
+[node name="NumberLabel" type="Label" parent="."]
+layout_mode = 0
+offset_right = 87.0
+offset_bottom = 20.0
+horizontal_alignment = 1
+vertical_alignment = 1
+
 [connection signal="mouse_entered" from="." to="." method="_on_mouse_entered"]
 [connection signal="mouse_exited" from="." to="." method="_on_mouse_exited"]

--- a/scripts/card.gd
+++ b/scripts/card.gd
@@ -1,7 +1,0 @@
-extends Control
-
-var value := ""
-
-func set_value(v):
-    value = str(v)
-    $Label.text = value

--- a/scripts/card.gd.uid
+++ b/scripts/card.gd.uid
@@ -1,1 +1,0 @@
-uid://hi6o5e6syo60


### PR DESCRIPTION
## Summary
- Display card numbers with a new NumberLabel
- Map first six card textures and allow assigning them via `set_number`
- Remove obsolete card script

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b46b8da53c832d8d1ba034ce05791c