### PR TITLE
Use random number for card draw and start table empty

### DIFF
--- a/scenes/card_table.tscn
+++ b/scenes/card_table.tscn
@@ -38,9 +38,3 @@ position = Vector2(20, 80)
 [node name="AceMenu" type="PopupMenu" parent="."]
 
 [node name="StarMenu" type="PopupMenu" parent="."]
-
-[node name="Card" parent="." instance=ExtResource("2_7cuvy")]
-offset_left = 222.0
-offset_top = 184.0
-offset_right = 309.0
-offset_bottom = 328.0

--- a/scripts/card_table.gd
+++ b/scripts/card_table.gd
@@ -18,22 +18,14 @@ func _ready():
 		$StarMenu.add_item(str(i), i)
 
 func _on_draw_pressed():
-	var values = [1,2,3,4,5,6,7,8,9,10,"A","Star"]
-	var choice = values[randi() % values.size()]
-	var card = card_scene.instantiate()
-	$CardsContainer.add_child(card)
-	card.position = Vector2(cards.size() * 60, 0)
-	cards.append(card)
-	card.set_value(choice)
-	if choice == "A":
-		current_card = card
-		$AceMenu.popup()
-	elif choice == "Star":
-		current_card = card
-		$StarMenu.popup()
-	else:
-		total_score += int(choice)
-		_update_score()
+        var num := randi() % 6 + 1
+        var card = card_scene.instantiate()
+        $CardsContainer.add_child(card)
+        card.position = Vector2(cards.size() * 60, 0)
+        cards.append(card)
+        card.set_number(num)
+        total_score += num
+        _update_score()
 
 func _on_ace_selected(id):
 	current_card.set_value(id)


### PR DESCRIPTION
## Summary
- simplify draw logic to generate a single random number and update score
- start card table empty by removing pre-spawned card node

## Testing
- `godot --version` *(fails: command not found)*
- `gdlint scripts/card_table.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b46b9454e8832dad1311cb2c0bf9b4