### PR TITLE
Refine card drawing buttons and scoring

### DIFF
--- a/scenes/card_table.tscn
+++ b/scenes/card_table.tscn
@@ -9,18 +9,26 @@ script = ExtResource("1")
 
 [node name="DrawButton" type="Button" parent="."]
 layout_mode = 0
-offset_left = 20.0
-offset_top = 20.0
-offset_right = 20.0
-offset_bottom = 20.0
+anchor_left = 0.5
+anchor_right = 0.5
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_left = -110.0
+offset_right = -10.0
+offset_top = -80.0
+offset_bottom = -20.0
 text = "Draw"
 
 [node name="HoldButton" type="Button" parent="."]
 layout_mode = 0
-offset_left = 120.0
-offset_top = 20.0
-offset_right = 120.0
-offset_bottom = 20.0
+anchor_left = 0.5
+anchor_right = 0.5
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_left = 10.0
+offset_right = 110.0
+offset_top = -80.0
+offset_bottom = -20.0
 text = "Hold"
 
 [node name="ScoreLabel" type="Label" parent="."]
@@ -29,7 +37,7 @@ offset_left = 220.0
 offset_top = 25.0
 offset_right = 220.0
 offset_bottom = 25.0
-text = "Score: 0"
+text = "Score: 0 | Total: 0"
 
 [node name="CardsContainer" type="Node2D" parent="."]
 position = Vector2(20, 80)

--- a/scripts/card_table.gd
+++ b/scripts/card_table.gd
@@ -2,43 +2,74 @@ extends Control
 
 var card_scene: PackedScene = preload("res://scenes/card.tscn")
 var total_score := 0
+var current_score := 0
 var cards := []
 var current_card: Control
 
 func _ready():
 	randomize()
-	$DrawButton.pressed.connect(_on_draw_pressed)
-	$HoldButton.pressed.connect(_on_hold_pressed)
-	$AceMenu.id_pressed.connect(_on_ace_selected)
-	$StarMenu.id_pressed.connect(_on_star_selected)
-	$ScoreLabel.text = "Score: 0"
-	$AceMenu.add_item("1", 1)
-	$AceMenu.add_item("10", 10)
-	for i in range(1, 11):
-		$StarMenu.add_item(str(i), i)
+        $DrawButton.pressed.connect(_on_draw_pressed)
+        $HoldButton.pressed.connect(_on_hold_pressed)
+        $AceMenu.id_pressed.connect(_on_ace_selected)
+        $StarMenu.id_pressed.connect(_on_star_selected)
+        $ScoreLabel.text = "Score: 0 | Total: 0"
+        $AceMenu.add_item("1", 1)
+        $AceMenu.add_item("10", 10)
+        for i in range(1, 11):
+                $StarMenu.add_item(str(i), i)
+        call_deferred("_setup_buttons")
+
+func _setup_buttons():
+        for button in [$DrawButton, $HoldButton]:
+                button.button_down.connect(_on_button_down.bind(button))
+                button.button_up.connect(_on_button_up.bind(button))
+                _make_button_round(button)
+                button.pivot_offset = button.size / 2
 
 func _on_draw_pressed():
-		var num := randi() % 6 + 1
-		var card = card_scene.instantiate()
-		$CardsContainer.add_child(card)
-		card.position = Vector2(cards.size() * 60, 0)
-		cards.append(card)
-		card.set_number(num)
-		total_score += num
-		_update_score()
+        while current_score <= 15:
+                var num := randi() % 6 + 1
+                var card = card_scene.instantiate()
+                $CardsContainer.add_child(card)
+                card.position = Vector2(cards.size() * 60, 0)
+                cards.append(card)
+                card.set_number(num)
+                current_card = card
+                current_score += num
+        _update_score()
 
 func _on_ace_selected(id):
-	current_card.set_value(id)
-	total_score += id
-	_update_score()
+        current_card.set_value(id)
+        current_score += id
+        _update_score()
 
 func _on_star_selected(id):
-	current_card.set_value(id)
-	total_score += id
-	_update_score()
+        current_card.set_value(id)
+        current_score += id
+        _update_score()
 
 func _on_hold_pressed():
-	$DrawButton.disabled = true
+        total_score += current_score
+        current_score = 0
+        for card in cards:
+                card.queue_free()
+        cards.clear()
+        _update_score()
 
 func _update_score():
-	$ScoreLabel.text = "Score: %d" % total_score
+        $ScoreLabel.text = "Score: %d | Total: %d" % [current_score, total_score]
+
+func _on_button_down(button):
+        button.scale = Vector2(0.9, 0.9)
+
+func _on_button_up(button):
+        button.scale = Vector2(1, 1)
+
+func _make_button_round(button):
+        for state in ["normal", "hover", "pressed"]:
+                var sb = button.get_theme_stylebox(state)
+                if sb:
+                        sb = sb.duplicate()
+                        if sb is StyleBoxFlat:
+                                sb.corner_radius_all = max(button.size.x, button.size.y)
+                        button.add_theme_stylebox_override(state, sb)


### PR DESCRIPTION
## Summary
- Move Draw and Hold buttons to bottom center of the screen
- Make buttons round and add press animations that scale them slightly
- Draw until the current score exceeds 15 and allow holding to accumulate a total score
- Display current and total scores together

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b47177c7cc832d92457ba4cfe78c16