### PR TITLE
Implement Card scene with front/back flipping

### DIFF
--- a/scenes/Card.tscn
+++ b/scenes/Card.tscn
@@ -11,11 +11,18 @@ anchor_bottom = 1.0
 script = ExtResource("1_4dx8l")
 
 [node name="Front" type="TextureRect" parent="."]
-layout_mode = 0
-offset_right = 920.0
-offset_bottom = 1463.0
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
 texture = ExtResource("2_qf083")
+stretch_mode = 3
+visible = false
 
 [node name="Back" type="TextureRect" parent="."]
-layout_mode = 0
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
 texture = ExtResource("3_40ytf")
+stretch_mode = 3

--- a/scripts/Card.gd
+++ b/scripts/Card.gd
@@ -1,26 +1,25 @@
-extends RigidBody3D
+extends Control
 
-@onready var front: Sprite3D = $Front
-@onready var back: Sprite3D = $Back
+@onready var front: TextureRect = $Front
+@onready var back: TextureRect = $Back
 
-var is_face_up := false
+var _face_up: bool = false
 
-func _ready() -> void:
-	set_face_up(false)
-	
-func set_face_up(up: bool) -> void:
-	is_face_up = up
-	front.visible = up
-	back.visible = not up
-	
-func show_front() -> void: set_face_up(true)
-func show_back() -> void: set_face_up(false)
+func show_front() -> void:
+    front.visible = true
+    back.visible = false
+    _face_up = true
 
-func flip(duration: float = 0.25) -> void:
-	var tw := create_tween().set_pause_mode(Tween.TWEEN_PAUSE_PROCESS)
-	tw.tween_property(self, "rotation_degrees:y", rotation_degrees.y + 90.0, duration * 0.5).set_trans(Tween.TRANS_CUBIC).set_ease(Tween.EASE_IN)
-	tw.tween_callback(Callable(self, "_toggle_face"))
-	tw.tween_property(self, "rotation_degrees:y", rotation_degrees.y + 180.0, duration * 0.5).set_trans(Tween.TRANS_CUBIC).set_ease(Tween.EASE_OUT)
-	
-func _toggle_face() -> void:
-	set_face_up(not is_face_up)
+func show_back() -> void:
+    front.visible = false
+    back.visible = true
+    _face_up = false
+
+func flip() -> void:
+    if _face_up:
+        show_back()
+    else:
+        show_front()
+
+func is_face_up() -> bool:
+    return _face_up

--- a/scripts/CardTable.gd
+++ b/scripts/CardTable.gd
@@ -1,6 +1,6 @@
 extends Control
 
-var card_scene: PackedScene = preload("res://scenes/card.tscn")
+var card_scene: PackedScene = preload("res://scenes/Card.tscn")
 var total_score := 0
 var current_score := 0
 var cards := []


### PR DESCRIPTION
## Summary
- Add `Card.tscn` scene with `Control` root and front/back texture rects
- Implement `Card.gd` script to manage front/back visibility and flipping
- Update `CardTable` to load the new `Card.tscn`

## Testing
- `godot --version` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*
- `gdlint scripts/Card.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d23088e4832da8c718f1ea363405