### PR TITLE
Add tween-based card flip animation

### DIFF
--- a/scripts/Card.gd
+++ b/scripts/Card.gd
@@ -3,7 +3,15 @@ extends Control
 @onready var front: TextureRect = $Front
 @onready var back: TextureRect = $Back
 
+@export var flip_time := 0.2
 var _face_up: bool = false
+
+func _ready() -> void:
+	_center_pivot()
+	resized.connect(_center_pivot)
+
+func _center_pivot() -> void:
+	pivot_offset = size / 2
 
 func show_front() -> void:
     front.visible = true
@@ -11,15 +19,21 @@ func show_front() -> void:
     _face_up = true
 
 func show_back() -> void:
-    front.visible = false
-    back.visible = true
-    _face_up = false
+	front.visible = false
+	back.visible = true
+	_face_up = false
 
-func flip() -> void:
-    if _face_up:
-        show_back()
-    else:
-        show_front()
+func flip(duration: float = flip_time) -> void:
+	var tw := create_tween()
+	tw.tween_property(self, "scale:x", 0.0, duration / 2).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN)
+	tw.tween_callback(Callable(self, "_swap_face"))
+	tw.tween_property(self, "scale:x", 1.0, duration / 2).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_OUT)
+
+func _swap_face() -> void:
+	if _face_up:
+		show_back()
+	else:
+		show_front()
 
 func is_face_up() -> bool:
     return _face_up

--- a/scripts/DeckManager.gd
+++ b/scripts/DeckManager.gd
@@ -3,6 +3,7 @@ extends Node3D
 @export var card_scene: PackedScene
 @export var deal_flip_after_move := true
 @export var deal_time := 0.35
+@export var flip_time := 0.2
 @export var deck_size := 24
 @export var stack_offset := Vector3(0.0, 0.003, 0.002)
 
@@ -59,5 +60,5 @@ func _on_draw_pressed() -> void:
 	tw.parallel().tween_property(card, "global_rotation", target.global_rotation, deal_time).set_trans(Tween.TRANS_CUBIC).set_ease(Tween.EASE_OUT)
 	
 	if deal_flip_after_move and ("flip" in card):
-		tw.tween_callback(Callable(card, "flip")).set_delay(0.02)
+		tw.tween_callback(Callable(card, "flip").bind(flip_time)).set_delay(0.02)
 	

--- a/scripts/card_table.gd
+++ b/scripts/card_table.gd
@@ -3,6 +3,7 @@ extends Control
 var card_scene: PackedScene = preload("res://scenes/Card.tscn")
 @export var deal_flip_after_move := true
 @export var deal_time := 0.35
+@export var flip_time := 0.2
 @export var deck_size := 24
 @export var stack_offset := Vector2(0.0, -2.0)
 
@@ -65,4 +66,4 @@ func _on_draw_pressed() -> void:
 	tw.parallel().tween_property(card, "global_rotation", target.global_rotation, deal_time).set_trans(Tween.TRANS_CUBIC).set_ease(Tween.EASE_OUT)
 
 	if deal_flip_after_move and ("flip" in card):
-		tw.tween_callback(Callable(card, "flip")).set_delay(0.02)
+		tw.tween_callback(Callable(card, "flip").bind(flip_time)).set_delay(0.02)


### PR DESCRIPTION
## Summary
- Add tween-driven flip animation to cards with centered pivot
- Allow tuning flip speed via new `flip_time` export
- Invoke the flip after dealing animations in 2D and 3D managers

## Testing
- `godot --version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6fd7f174832da4bdf49e798195f0