### PR TITLE
Add physics card and table scene

### DIFF
--- a/scenes/PhysicsCard3d.tscn
+++ b/scenes/PhysicsCard3d.tscn
@@ -1,0 +1,26 @@
+[gd_scene load_steps=6 format=3 uid="uid://physicscard3d"]
+
+[ext_resource type="Texture2D" path="res://assets/cards_png/gpt_game_assets/cards/card_back.png" id="1"]
+
+[sub_resource type="PhysicsMaterial" id="1"]
+friction = 0.2
+
+[sub_resource type="PlaneMesh" id="2"]
+size = Vector2(1.0, 1.5)
+
+[sub_resource type="StandardMaterial3D" id="3"]
+albedo_texture = ExtResource("1")
+two_sided = true
+
+[sub_resource type="BoxShape3D" id="4"]
+size = Vector3(1.0, 0.02, 1.5)
+
+[node name="PhysicsCard3d" type="RigidBody3D"]
+physics_material_override = SubResource("1")
+
+[node name="Mesh" type="MeshInstance3D" parent="."]
+mesh = SubResource("2")
+material_override = SubResource("3")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+shape = SubResource("4")

--- a/scenes/PhysicsTable.tscn
+++ b/scenes/PhysicsTable.tscn
@@ -1,0 +1,49 @@
+[gd_scene load_steps=7 format=3 uid="uid://physicstable"]
+
+[ext_resource type="Texture2D" path="res://assets/cards_png/gpt_game_assets/background_2.png" id="1"]
+[ext_resource type="Script" path="res://scripts/PhysicsDeckManager.gd" id="2"]
+
+[sub_resource type="PhysicsMaterial" id="1"]
+friction = 0.2
+
+[sub_resource type="PlaneMesh" id="2"]
+size = Vector2(6, 6)
+
+[sub_resource type="StandardMaterial3D" id="3"]
+albedo_texture = ExtResource("1")
+
+[sub_resource type="BoxShape3D" id="4"]
+size = Vector3(6, 0.1, 6)
+
+[node name="PhysicsTable" type="Node3D"]
+script = ExtResource("2")
+
+[node name="Table" type="StaticBody3D" parent="."]
+physics_material_override = SubResource("1")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Table"]
+shape = SubResource("4")
+
+[node name="Mesh" type="MeshInstance3D" parent="Table"]
+mesh = SubResource("2")
+material_override = SubResource("3")
+
+[node name="DeckSpawn" type="Marker3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
+
+[node name="Camera3D" type="Camera3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 0.866025, -0.5, 0, 0.5, 0.866025, 0, 4, 6)
+
+[node name="UI" type="CanvasLayer" parent="."]
+
+[node name="DrawButton" type="Button" parent="UI"]
+anchors_preset = 3
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -110.0
+offset_top = -50.0
+offset_right = -10.0
+offset_bottom = -10.0
+text = "Draw"

--- a/scripts/PhysicsDeckManager.gd
+++ b/scripts/PhysicsDeckManager.gd
@@ -1,0 +1,21 @@
+extends Node3D
+
+@export var card_scene: PackedScene = preload("res://scenes/PhysicsCard3d.tscn")
+@export var spawn_height := 2.0
+@export var throw_strength := 3.0
+
+@onready var deck_spawn: Marker3D = $DeckSpawn
+@onready var draw_button: Button = $UI/DrawButton
+
+func _ready() -> void:
+    if draw_button:
+        draw_button.pressed.connect(_on_draw_pressed)
+
+func _on_draw_pressed() -> void:
+    var card := card_scene.instantiate() as RigidBody3D
+    add_child(card)
+    var pos := deck_spawn.global_transform.origin
+    pos.y += spawn_height
+    card.global_transform.origin = pos
+    card.rotation = Vector3(0.0, randf_range(-PI, PI), 0.0)
+    card.linear_velocity = Vector3(randf_range(-1.0, 1.0), -1.0, -throw_strength)


### PR DESCRIPTION
## Summary
- Add RigidBody3D card scene with collision shape
- Create table scene using background_2 and draw button
- Introduce PhysicsDeckManager to throw cards onto table

## Testing
- `godot --headless --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bab6fa409c832da64802d34fc365a4