### PR TITLE
Add front and back meshes for PhysicsCard3d

### DIFF
--- a/scenes/PhysicsCard3d.tscn
+++ b/scenes/PhysicsCard3d.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=6 format=3 uid="uid://bn4adcbcwsgii"]
+[gd_scene load_steps=8 format=3 uid="uid://bn4adcbcwsgii"]
 
-[ext_resource type="Texture2D" uid="uid://bvs4wg31wwq50" path="res://assets/cards_png/gpt_game_assets/cards/card_back.png" id="1"]
+[ext_resource type="Texture2D" uid="uid://bdob48q2o5xk6" path="res://assets/cards_png/gpt_game_assets/cards_simple/thief.png" id="1"]
+[ext_resource type="Texture2D" uid="uid://b5pqtkn55oitp" path="res://assets/cards_png/gpt_game_assets/cards_simple/Back.png" id="2"]
 
 [sub_resource type="PhysicsMaterial" id="1"]
 friction = 0.2
@@ -14,11 +15,19 @@ size = Vector2(1, 1.5)
 [sub_resource type="BoxShape3D" id="4"]
 size = Vector3(1, 0.0565137, 1.5)
 
+[sub_resource type="StandardMaterial3D" id="5"]
+albedo_texture = ExtResource("2")
+
 [node name="PhysicsCard3d" type="RigidBody3D"]
 physics_material_override = SubResource("1")
 
-[node name="Mesh" type="MeshInstance3D" parent="."]
+[node name="FrontMesh" type="MeshInstance3D" parent="."]
 material_override = SubResource("3")
+mesh = SubResource("2")
+
+[node name="BackMesh" type="MeshInstance3D" parent="."]
+transform = Transform3D(-1, 0, 0, 0, 1, 0, 0, 0, -1, 0, 0, 0)
+material_override = SubResource("5")
 mesh = SubResource("2")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="."]


### PR DESCRIPTION
## Summary
- Split PhysicsCard3d mesh into separate front and back meshes
- Apply thief and back card textures to front and back with unique materials
- Rotate back mesh 180° around the Y axis to show reverse side

## Testing
- `godot --version` *(fails: command not found)*
- `godot4 --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4f026038832dbb5f667b3d882899