### PR TITLE
Disable backface culling on card materials

### DIFF
--- a/scenes/PhysicsCard3d.tscn
+++ b/scenes/PhysicsCard3d.tscn
@@ -8,12 +8,14 @@ friction = 0.2
 
 [sub_resource type="StandardMaterial3D" id="3"]
 albedo_texture = ExtResource("1")
+cull_mode = 2
 
 [sub_resource type="PlaneMesh" id="2"]
 size = Vector2(1, 1.5)
 
 [sub_resource type="StandardMaterial3D" id="5"]
 albedo_texture = ExtResource("2")
+cull_mode = 2
 
 [sub_resource type="BoxShape3D" id="4"]
 size = Vector3(1, 0.0565137, 1.5)


### PR DESCRIPTION
## Summary
- Disable backface culling for card front and back materials so both sides render

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc99e41c8832db9776e39fc53ec69