### PR TITLE
Add score tracking for Card3D deck

### DIFF
--- a/scenes/Card3D.tscn
+++ b/scenes/Card3D.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=10 format=3 uid="uid://bdt0hshbn36hf"]
+[gd_scene load_steps=11 format=3 uid="uid://bdt0hshbn36hf"]
 
 [ext_resource type="Texture2D" uid="uid://2pfq0a84pyh" path="res://assets/cards_png/gpt_game_assets/cards_simple/thief.png" id="1"]
 [ext_resource type="Texture2D" uid="uid://bwwxasdeyh3la" path="res://assets/cards_png/gpt_game_assets/cards_simple/Back.png" id="2"]
+[ext_resource type="Script" path="res://scripts/Card3D.gd" id="3"]
 
 [sub_resource type="PhysicsMaterial" id="1"]
 friction = 0.6
@@ -38,6 +39,7 @@ physics_material_override = SubResource("1")
 continuous_cd = true
 linear_damp = 0.15
 angular_damp = 0.25
+script = ExtResource("3")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="."]
 transform = Transform3D(-15, 1.31134e-06, 0, -1.31134e-06, -15, 0, 0, 0, 15, -1.25631e-11, 0.00028741, 0)
@@ -59,3 +61,9 @@ transform = Transform3D(15, -3.57628e-06, -1.31134e-06, 3.57628e-06, 15, -1.3113
 material_override = SubResource("7")
 cast_shadow = 0
 mesh = SubResource("5")
+
+[node name="NumberLabel" type="Label3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.00976899, 0)
+billboard = 1
+pixel_size = 0.004
+text = "0"

--- a/scenes/DeckManager.tscn
+++ b/scenes/DeckManager.tscn
@@ -31,3 +31,8 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.303163, -0.825155)
 [node name="DrawButton" type="Button" parent="CanvasLayer"]
 offset_right = 8.0
 offset_bottom = 8.0
+
+[node name="ScoreLabel" type="Label" parent="CanvasLayer"]
+offset_left = 10.0
+offset_top = 10.0
+text = "CURRENT SCORE: 0"

--- a/scripts/Card3D.gd
+++ b/scripts/Card3D.gd
@@ -1,0 +1,7 @@
+extends RigidBody3D
+
+var number_value: int = randi_range(1, 6)
+@onready var number_label: Label3D = $NumberLabel
+
+func _ready() -> void:
+    number_label.text = str(number_value)

--- a/scripts/DeckManager.gd
+++ b/scripts/DeckManager.gd
@@ -13,10 +13,12 @@ extends Node3D
 @onready var deck_spawn: Node3D = $DeckSpawn
 @onready var targets_parent: Node3D = $DealTargets
 @onready var draw_button: Button = $"../CanvasLayer/DrawButton"
+@onready var score_label: Label = $"../CanvasLayer/ScoreLabel"
 
 var targets: Array[Node3D] = []
 var deck: Array[Node3D] = []
 var next_target_idx := 0
+var current_score: int = 0
 
 func _ready() -> void:
 	for c in targets_parent.get_children():
@@ -30,11 +32,14 @@ func _ready() -> void:
 	
 
 func _build_deck() -> void:
-	for c in deck:
-		if is_instance_valid(c):
-			c.queue_free()
-	deck.clear()
-	next_target_idx = 0
+        for c in deck:
+                if is_instance_valid(c):
+                        c.queue_free()
+        deck.clear()
+        next_target_idx = 0
+        current_score = 0
+        if score_label:
+                score_label.text = "CURRENT SCORE: 0"
 	
 	var base := deck_spawn.global_transform
 	for i in range(deck_size):
@@ -54,16 +59,19 @@ func _on_draw_pressed() -> void:
 		return
 
 	
-	var card: Variant = deck.pop_front()
-	var target := targets[next_target_idx]
-	next_target_idx += 1
+        var card: Variant = deck.pop_front()
+        var target := targets[next_target_idx]
+        next_target_idx += 1
 
 	var dest_pos := target.global_position + _random_offset(target_jitter)
 	var tw := create_tween()
 	tw.tween_property(card, "global_position", target.global_position, deal_time).set_trans(Tween.TRANS_CUBIC).set_ease(Tween.EASE_OUT)
-	tw.parallel().tween_property(card, "global_rotation", target.global_rotation, deal_time).set_trans(Tween.TRANS_CUBIC).set_ease(Tween.EASE_OUT)
-	if deal_flip_after_move and ("flip" in card):
-		tw.tween_callback(Callable(card, "flip").bind(flip_time)).set_delay(0.02)
+        tw.parallel().tween_property(card, "global_rotation", target.global_rotation, deal_time).set_trans(Tween.TRANS_CUBIC).set_ease(Tween.EASE_OUT)
+        if deal_flip_after_move and ("flip" in card):
+                tw.tween_callback(Callable(card, "flip").bind(flip_time)).set_delay(0.02)
+        if score_label and "number_value" in card:
+                current_score += card.number_value
+                score_label.text = "CURRENT SCORE: %d" % current_score
 
 
 func _random_offset(range: Vector3) -> Vector3:


### PR DESCRIPTION
## Summary
- Persist random value on each Card3D and expose it via number_value
- Track total of drawn card values and show it with a new ScoreLabel in DeckManager scene

## Testing
- `godot --headless --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbfd2c3c34832d8ec88a196949cae8