### PR TITLE
Randomize card faces and stable numbers

### DIFF
--- a/scripts/Card3D.gd
+++ b/scripts/Card3D.gd
@@ -1,7 +1,20 @@
 extends RigidBody3D
 
-var number_value: int = randi_range(1, 6)
+const FACE_TEXTURES := [
+    preload("res://assets/cards_png/gpt_game_assets/cards_simple/coins.png"),
+    preload("res://assets/cards_png/gpt_game_assets/cards_simple/thief.png"),
+]
+
+var number_value: int
+
 @onready var number_label: Label3D = $NumberLabel
+@onready var front: MeshInstance3D = $Front
 
 func _ready() -> void:
+    number_value = randi_range(1, 6)
     number_label.text = str(number_value)
+
+    var texture := FACE_TEXTURES[randi() % FACE_TEXTURES.size()]
+    var mat := front.get_active_material(0).duplicate()
+    mat.albedo_texture = texture
+    front.material_override = mat


### PR DESCRIPTION
## Summary
- assign each 3D card a random face texture (coins or thief)
- generate a number for each card on spawn and keep it consistent

## Testing
- `godot --headless --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc61cabebc832d9bba749359fffde3