### PR TITLE
Offset 3D card number label from surface

### DIFF
--- a/scenes/Card3D.tscn
+++ b/scenes/Card3D.tscn
@@ -63,7 +63,8 @@ cast_shadow = 0
 mesh = SubResource("5")
 
 [node name="NumberLabel" type="Label3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.00976899, 0)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.01076899, 0)
 pixel_size = 0.004
 billboard = 1
+no_depth_test = true
 text = "0"


### PR DESCRIPTION
## Summary
- Move NumberLabel slightly away from card face and enable no-depth-test to avoid overlap

## Testing
- `godot --version` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1d8864a4832db7d295dca5169ee2