### PR TITLE
Enable Card3D collisions with other cards

### DIFF
--- a/scenes/Card3D.tscn
+++ b/scenes/Card3D.tscn
@@ -34,6 +34,7 @@ clearcoat = 0.05
 
 [node name="Card3D" type="RigidBody3D"]
 collision_layer = 2
+collision_mask = 3
 mass = 0.02
 physics_material_override = SubResource("1")
 continuous_cd = true


### PR DESCRIPTION
## Summary
- Allow cards to collide with both the table and other cards by expanding Card3D's collision mask

## Testing
- `godot --headless --version` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1dbcd5bc832d9105a36ae01724aa