### PR TITLE
Fix Card3D number label reference

### DIFF
--- a/scripts/Card3D.gd
+++ b/scripts/Card3D.gd
@@ -2,8 +2,9 @@ extends RigidBody3D
 
 var number_value: int = 0
 
-@onready var number_label: Label = $NumberViewport/NumberLabel
+@onready var number_label: Label3D = $NumberLabel
 
 func _ready() -> void:
-	number_value = randi_range(1, 6)
-	number_label.text = str(number_value)
+        number_value = randi_range(1, 6)
+        assert(number_label != null)
+        number_label.text = str(number_value)


### PR DESCRIPTION
## Summary
- reference NumberLabel as a Label3D instead of a Label
- check for a missing NumberLabel before setting its text

## Testing
- `godot --headless --quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bde12bd4b8832db2b7b72d6b2fd326