### PR TITLE
Align card labels with card face

### DIFF
--- a/scenes/Card3D.tscn
+++ b/scenes/Card3D.tscn
@@ -66,6 +66,7 @@ mesh = SubResource("5")
 [node name="NumberLabel" type="Label3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.010769, 0)
 pixel_size = 0.004
-billboard = 1
-no_depth_test = true
+billboard = 0
+double_sided = false
+no_depth_test = false
 text = "0"

--- a/scripts/Card3D.gd
+++ b/scripts/Card3D.gd
@@ -2,8 +2,8 @@ extends RigidBody3D
 
 var number_value: int = 0
 
-@onready var number_label: Label = $NumberViewport/NumberLabel
+@onready var number_label: Label3D = $NumberLabel
 
 func _ready() -> void:
-	number_value = randi_range(1, 6)
-	number_label.text = str(number_value)
+    number_value = randi_range(1, 6)
+    number_label.text = str(number_value)


### PR DESCRIPTION
## Summary
- Align 3D card label to match card face orientation
- Hide label when back side is facing away and allow depth occlusion
- Update script to reference Label3D directly

## Testing
- `godot --headless --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bde803385c832d91444f95d06e2353