### PR TITLE
Randomize card faces

### DIFF
--- a/scripts/Card3D.gd
+++ b/scripts/Card3D.gd
@@ -1,9 +1,18 @@
 extends RigidBody3D
 
+@export var face_textures: Array[Texture2D] = [
+        preload("res://assets/cards_png/gpt_game_assets/cards_simple/coins.png"),
+        preload("res://assets/cards_png/gpt_game_assets/cards_simple/draws.png"),
+        preload("res://assets/cards_png/gpt_game_assets/cards_simple/thief.png"),
+]
+
 var number_value: int = 0
 
 @onready var number_label: Label3D = $NumberLabel
 
 func _ready() -> void:
-	number_value = randi_range(1, 6)
-	number_label.text = str(number_value)
+        number_value = randi_range(1, 6)
+        number_label.text = str(number_value)
+
+func set_face_texture(tex: Texture2D) -> void:
+        $Front.material_override.albedo_texture = tex

--- a/scripts/DeckManager.gd
+++ b/scripts/DeckManager.gd
@@ -42,15 +42,17 @@ func _build_deck() -> void:
 		score_label.text = "CURRENT SCORE: 0"
 	
 	var base := deck_spawn.global_transform
-	for i in range(deck_size):
-		var card := card_scene.instantiate() as Node3D
-		deck_root.add_child(card)
-		card.global_transform = base
-		card.translate(stack_offset * float(i) + _random_offset(deck_jitter))
-		card.rotate_y(deg_to_rad(randf_range(-3.0, 3.0)))
-		if "show_back" in card:
-			card.call_deferred("show_back")
-		deck.push_front(card)
+        for i in range(deck_size):
+                var card := card_scene.instantiate() as Node3D
+                deck_root.add_child(card)
+                card.global_transform = base
+                card.translate(stack_offset * float(i) + _random_offset(deck_jitter))
+                card.rotate_y(deg_to_rad(randf_range(-3.0, 3.0)))
+                var chosen_tex: Texture2D = card.face_textures[randi_range(0, card.face_textures.size() - 1)]
+                card.set_face_texture(chosen_tex)
+                if "show_back" in card:
+                        card.call_deferred("show_back")
+                deck.push_front(card)
 		
 func _on_draw_pressed() -> void:
 	if deck.is_empty():


### PR DESCRIPTION
## Summary
- preload a set of face textures for 3D cards and add API to set the face
- draw deck now randomizes a card face texture when building the deck

## Testing
- `godot --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbd3419b4832da51af527c2170481