### PR TITLE
Cast material override to StandardMaterial3D

### DIFF
--- a/scripts/Card3D.gd
+++ b/scripts/Card3D.gd
@@ -15,7 +15,7 @@ func _ready() -> void:
 	number_label.text = str(number_value)
 
 func set_face_texture(tex: Texture2D) -> void:
-	var mat : StandardMaterial3D = $Front.material_override
-	mat = mat.duplicate() if mat else StandardMaterial3D.new()
-	mat.albedo_texture = tex
-	$Front.material_override = mat
+        var mat: StandardMaterial3D = $Front.material_override as StandardMaterial3D
+        mat = mat.duplicate() if mat else StandardMaterial3D.new()
+        mat.albedo_texture = tex
+        $Front.material_override = mat


### PR DESCRIPTION
## Summary
- Cast the front material to `StandardMaterial3D` in `Card3D.set_face_texture` to ensure proper duplication and assignment

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc639e07c832db9eec84f72581f9c