### PR TITLE
Randomize card face textures

### DIFF
--- a/scripts/Card.gd
+++ b/scripts/Card.gd
@@ -4,6 +4,7 @@ extends Control
 @onready var back: TextureRect = $Back
 
 @export var flip_time := 0.2
+@export var face_textures: Array[Texture2D] = []
 var _face_up: bool = false
 var _base_scale: Vector2
 
@@ -13,12 +14,15 @@ func _ready() -> void:
 	resized.connect(_center_pivot)
 
 func _center_pivot() -> void:
-	pivot_offset = size / 2
+        pivot_offset = size / 2
+
+func set_face_texture(tex: Texture2D) -> void:
+        front.texture = tex
 
 func show_front() -> void:
-	front.visible = true
-	back.visible = false
-	_face_up = true
+        front.visible = true
+        back.visible = false
+        _face_up = true
 
 func show_back() -> void:
 	front.visible = false

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -14,6 +14,7 @@ var deck: Array[Control] = []
 var next_target_idx := 0
 
 func _ready() -> void:
+        randomize()
         for c in targets_parent.get_children():
                 if c is Control:
                         targets.append(c as Control)
@@ -30,6 +31,10 @@ func _build_deck() -> void:
                 var card := card_scene.instantiate() as Control
                 add_child(card)
                 card.global_position = deck_spawn.global_position + stack_offset * float(i)
+                if "face_textures" in card and "set_face_texture" in card:
+                        var textures: Array = card.face_textures
+                        if textures.size() > 0:
+                                card.set_face_texture(textures[randi() % textures.size()])
                 if "show_back" in card:
                         card.call_deferred("show_back")
                 deck.push_front(card)


### PR DESCRIPTION
## Summary
- Export selectable face textures and method to set Card front texture
- Randomize card faces when building deck and seed RNG at start

## Testing
- `godot --version` (command not found)
- `apt-get update` (403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68bfc8bd58c4832d9a5d2b9049e96c8d