### PR TITLE
Randomize card face textures in PhysicsDeckManager

### DIFF
--- a/scripts/PhysicsDeckManager.gd
+++ b/scripts/PhysicsDeckManager.gd
@@ -12,17 +12,21 @@ extends Node3D
 @onready var draw_button: Button = $UI/DrawButton
 
 func _ready() -> void:
-	if draw_button:
-		draw_button.pressed.connect(_on_draw_pressed)
+        randomize()
+        if draw_button:
+                draw_button.pressed.connect(_on_draw_pressed)
 
 func _on_draw_pressed() -> void:
-	var card := card_scene.instantiate() as RigidBody3D
-	add_child(card)
-	
-	var pos := deck_spawn.global_transform.origin
-	pos.y += spawn_height
-	card.global_transform.origin = pos
-	card.rotation = Vector3(0.0, randf_range(-0.1*PI, 0.1*PI), 0.0)
+        var card := card_scene.instantiate() as RigidBody3D
+        add_child(card)
+
+        var tex = card.face_textures[randi_range(0, card.face_textures.size() - 1)]
+        card.set_face_texture(tex)
+
+        var pos := deck_spawn.global_transform.origin
+        pos.y += spawn_height
+        card.global_transform.origin = pos
+        card.rotation = Vector3(0.0, randf_range(-0.1*PI, 0.1*PI), 0.0)
 	card.linear_velocity = Vector3(randf_range(-1.0, 1.0), -1.0, -throw_strength)
 	var gravity := ProjectSettings.get_setting("physics/3d/default_gravity") as float
 	var fall_time := sqrt((2.0 * spawn_height) / gravity)


### PR DESCRIPTION
## Summary
- Seed random number generator in `PhysicsDeckManager` when scene is ready
- Apply a random face texture to each spawned card

## Testing
- `godot --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bfcc7ff94c832d9ff23a5f7137b708