### PR TITLE
Limit deck card spawns and align drop spacing

### DIFF
--- a/scenes/PhysicsTable.tscn
+++ b/scenes/PhysicsTable.tscn
@@ -19,6 +19,7 @@ size = Vector2(6, 6)
 
 [node name="PhysicsTable" type="Node3D"]
 script = ExtResource("2")
+row_spacing = 0.5
 
 [node name="Table" type="StaticBody3D" parent="."]
 transform = Transform3D(1.67017, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
@@ -51,6 +52,18 @@ offset_top = -50.0
 offset_right = -10.0
 offset_bottom = -10.0
 text = "Draw"
+
+[node name="HoldButton" type="Button" parent="UI"]
+anchors_preset = 3
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -220.0
+offset_top = -50.0
+offset_right = -120.0
+offset_bottom = -10.0
+text = "Hold"
 
 [node name="WorldEnvironment" type="WorldEnvironment" parent="."]
 environment = SubResource("Environment_i431q")

--- a/scripts/PhysicsDeckManager.gd
+++ b/scripts/PhysicsDeckManager.gd
@@ -3,6 +3,9 @@ extends Node3D
 @export var card_scene: PackedScene = preload("res://scenes/Card3D.tscn")
 @export var spawn_height := 2.0
 @export var throw_strength := 5.0
+const MAX_CARDS := 10
+@export var row_spacing := 0.5
+var card_count := 0
 
 # Amount of rotation in radians performed during the fall. A default of 270
 # degrees makes the card land face up when dropped from the spawn height.
@@ -10,24 +13,46 @@ extends Node3D
 
 @onready var deck_spawn: Marker3D = $DeckSpawn
 @onready var draw_button: Button = $UI/DrawButton
+@onready var hold_button: Button = $UI/HoldButton
+var cards: Array[RigidBody3D] = []
 
 func _ready() -> void:
-		randomize()
-		if draw_button:
-				draw_button.pressed.connect(_on_draw_pressed)
+                randomize()
+                if draw_button:
+                                draw_button.pressed.connect(_on_draw_pressed)
+                if hold_button:
+                                hold_button.pressed.connect(_on_hold_pressed)
 
 func _on_draw_pressed() -> void:
-	var card := card_scene.instantiate() as RigidBody3D
-	add_child(card)
+        if card_count >= MAX_CARDS:
+                return
+        var card := card_scene.instantiate() as RigidBody3D
+        add_child(card)
+        cards.append(card)
 
 	var tex = card.face_textures[randi_range(0, card.face_textures.size() - 1)]
 	card.set_face_texture(tex)
 
 	var pos := deck_spawn.global_transform.origin
 	pos.y += spawn_height
+	pos.x += row_spacing * card_count
 	card.global_transform.origin = pos
 	card.rotation = Vector3(0.0, randf_range(-0.1*PI, 0.1*PI), 0.0)
-	card.linear_velocity = Vector3(randf_range(-1.0, 1.0), -6.0, -throw_strength)
+	card.linear_velocity = Vector3(0.5, -2.0, -throw_strength)
 	var gravity := ProjectSettings.get_setting("physics/3d/default_gravity") as float
 	var fall_time := sqrt((2.0 * spawn_height) / gravity)
-	card.angular_velocity = Vector3(0.0, 0.0, flip_strength / fall_time)
+        card.angular_velocity = Vector3(0.0, 0.0, flip_strength / fall_time)
+        card_count += 1
+
+func _on_hold_pressed() -> void:
+        draw_button.disabled = true
+        hold_button.disabled = true
+        for card in cards:
+                card.linear_velocity = Vector3(5.0, 2.0, 0.0)
+                card.angular_velocity = Vector3(0.0, 5.0, 0.0)
+        await get_tree().create_timer(0.5).timeout
+        for card in cards:
+                if card:
+                        card.queue_free()
+        cards.clear()
+        card_count = 0


### PR DESCRIPTION
## Summary
- Limit physics deck to 10 cards with a counter and row spacing control
- Stop spawning once maximum cards reached and offset each card horizontally
- Expose row spacing on the PhysicsTable scene for editor tweaking
- Add Hold button to sweep spawned cards off the table and end dealing

## Testing
- `godot --headless --path . --quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c24eb7a530832db77c15c039c8a4b5