### PR TITLE
Add score tracking to physics deck

### DIFF
--- a/scenes/PhysicsTable.tscn
+++ b/scenes/PhysicsTable.tscn
@@ -76,6 +76,14 @@ scale = Vector2(0.15, 0.15)
 texture_normal = ExtResource("4_dl2mo")
 texture_pressed = ExtResource("6_kxug7")
 
+[node name="ScoreLabel" type="Label" parent="UI"]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+text = "0"
+
 [node name="WorldEnvironment" type="WorldEnvironment" parent="."]
 environment = SubResource("Environment_i431q")
 

--- a/scripts/PhysicsDeckManager.gd
+++ b/scripts/PhysicsDeckManager.gd
@@ -6,6 +6,7 @@ extends Node3D
 const MAX_CARDS := 10
 @export var row_spacing := 0.5
 var card_count := 0
+var total_score := 0
 
 # Amount of rotation in radians performed during the fall. A default of 270
 # degrees makes the card land face up when dropped from the spawn height.
@@ -14,6 +15,7 @@ var card_count := 0
 @onready var deck_spawn: Marker3D = $DeckSpawn
 @onready var draw_button: TextureButton = $UI/DrawButton
 @onready var hold_button: TextureButton = $UI/HoldButton
+@onready var score_label: Label = $UI/ScoreLabel
 var cards: Array[RigidBody3D] = []
 
 func _ready() -> void:
@@ -45,8 +47,10 @@ func _on_draw_pressed() -> void:
 	
 	var gravity := ProjectSettings.get_setting("physics/3d/default_gravity") as float
 	var fall_time := sqrt((2.0 * spawn_height) / gravity)
-	card.angular_velocity = Vector3(0.0, 0.0, flip_strength / fall_time)
-	card_count += 1
+        card.angular_velocity = Vector3(0.0, 0.0, flip_strength / fall_time)
+        card_count += 1
+        total_score += card.number_value
+        score_label.text = str(total_score)
 
 func _on_hold_pressed() -> void:
 	draw_button.disabled = true
@@ -58,7 +62,9 @@ func _on_hold_pressed() -> void:
 	for card in cards:
 		if card:
 			card.queue_free()
-	cards.clear()
-	card_count = 0
-	draw_button.disabled = false
-	hold_button.disabled = false
+        cards.clear()
+        card_count = 0
+        total_score = 0
+        score_label.text = "0"
+        draw_button.disabled = false
+        hold_button.disabled = false


### PR DESCRIPTION
## Summary
- Display running score on physics table via new ScoreLabel
- Track total score in PhysicsDeckManager and update label on draw or reset on hold

## Testing
- `godot --version` *(fails: command not found)*
- `apt-get install -y godot4` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c406dcf838832da7f0548a03cabd99