### PR TITLE
Add total score label to physics table UI

### DIFF
--- a/scenes/PhysicsTable.tscn
+++ b/scenes/PhysicsTable.tscn
@@ -121,6 +121,25 @@ theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
 text = "0"
 horizontal_alignment = 1
 
+[node name="TotalScoreLabel" type="Label" parent="UI"]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -60.0
+offset_top = -282.0
+offset_right = -20.0
+offset_bottom = -254.0
+grow_horizontal = 2
+grow_vertical = 2
+scale = Vector2(2, 2)
+theme = SubResource("Theme_teiip")
+theme_override_colors/font_color = Color(0.832235, 0.713053, 0.620879, 1)
+theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
+text = "Total: 0"
+horizontal_alignment = 1
+
 [node name="WorldEnvironment" type="WorldEnvironment" parent="."]
 environment = SubResource("Environment_i431q")
 


### PR DESCRIPTION
## Summary
- Add `TotalScoreLabel` under the UI canvas to track cumulative score

## Testing
- ❌ `godot --headless --check-only scenes/PhysicsTable.tscn` *(godot: command not found)*
- ⚠️ `apt-get update` *(403 Forbidden when attempting to update package lists)*

------
https://chatgpt.com/codex/tasks/task_e_68c4751d2f04832da6b1dc33af2247d4