### PR TITLE
Add building selection UI to Kingdom scene

### DIFF
--- a/scenes/Kingdom.gd
+++ b/scenes/Kingdom.gd
@@ -1,14 +1,38 @@
 extends Node3D
 
+const BUILDING_TILE_SCENE := preload("res://scenes/ui/BuildingTile.tscn")
+
 @onready var play_button: TextureButton = $UI/PlayButton
+@onready var building_tile_container: HBoxContainer = $UI/BuildingTileContainer/TileList
+@onready var level_root: Node3D = $LevelRoot
 
 func _ready() -> void:
-	_wire_ui()
-	
+        _wire_ui()
+        _create_building_tiles()
+
 
 func _wire_ui() -> void:
-	if play_button and not play_button.pressed.is_connected(_on_play_pressed):
-		play_button.pressed.connect(_on_play_pressed)
+        if play_button and not play_button.pressed.is_connected(_on_play_pressed):
+                play_button.pressed.connect(_on_play_pressed)
+
+
+func _create_building_tiles() -> void:
+        if not building_tile_container:
+                return
+
+        for child in building_tile_container.get_children():
+                child.queue_free()
+
+        var buildings: Array[Node3D] = []
+        for child in level_root.get_children():
+                if child is Node3D and child.name.begins_with("Building"):
+                        buildings.append(child)
+                        child.visible = false
+
+        for building in buildings:
+                var tile := BUILDING_TILE_SCENE.instantiate()
+                building_tile_container.add_child(tile)
+                tile.setup(building)
 		
 	
 func _on_play_pressed() -> void:

--- a/scenes/Kingdom.tscn
+++ b/scenes/Kingdom.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=12 format=3 uid="uid://fwfch7tbk6j4"]
+[gd_scene load_steps=13 format=3 uid="uid://fwfch7tbk6j4"]
 
 [ext_resource type="Texture2D" uid="uid://cl282gwrr1o4a" path="res://assets/ui/buttons/play.png" id="1_cj0vx"]
 [ext_resource type="Script" uid="uid://dtdur3vgsfwc5" path="res://scenes/Kingdom.gd" id="1_h5qp7"]
 [ext_resource type="Texture2D" uid="uid://lm30aibs7ft5" path="res://assets/ui/buttons/play_pressed.png" id="2_h5qp7"]
+[ext_resource type="PackedScene" path="res://scenes/ui/BuildingTile.tscn" id="3_y2dt7"]
 
 [sub_resource type="PlaneMesh" id="PlaneMesh_h5qp7"]
 
@@ -35,6 +36,19 @@ offset_bottom = 1484.0
 scale = Vector2(0.15, 0.15)
 texture_normal = ExtResource("1_cj0vx")
 texture_pressed = ExtResource("2_h5qp7")
+
+[node name="BuildingTileContainer" type="MarginContainer" parent="UI"]
+offset_left = 240.0
+offset_top = 920.0
+offset_right = 1720.0
+offset_bottom = 1400.0
+
+[node name="TileList" type="HBoxContainer" parent="UI/BuildingTileContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+alignment = 1
+theme_override_constants/separation = 24
 
 [node name="LevelRoot" type="Node3D" parent="."]
 

--- a/scenes/ui/BuildingTile.gd
+++ b/scenes/ui/BuildingTile.gd
@@ -1,0 +1,35 @@
+extends Control
+
+@onready var preview_root: Node3D = $ViewportContainer/SubViewport/PreviewRoot
+@onready var spawn_button: TextureButton = $SpawnButton
+
+var building_node: Node3D
+var preview_instance: Node3D = null
+
+func setup(building: Node3D) -> void:
+    building_node = building
+    if building_node:
+        building_node.visible = false
+    _populate_preview()
+    if not spawn_button.pressed.is_connected(_on_spawn_pressed):
+        spawn_button.pressed.connect(_on_spawn_pressed)
+
+
+func _populate_preview() -> void:
+    if preview_instance:
+        preview_instance.queue_free()
+        preview_instance = null
+    if not building_node:
+        return
+    preview_instance = building_node.duplicate()
+    preview_instance.visible = true
+    preview_instance.transform = Transform3D.IDENTITY
+    preview_instance.scale = Vector3.ONE * 0.2
+    preview_root.add_child(preview_instance)
+
+
+func _on_spawn_pressed() -> void:
+    if not building_node:
+        return
+    building_node.visible = true
+    spawn_button.disabled = true

--- a/scenes/ui/BuildingTile.tscn
+++ b/scenes/ui/BuildingTile.tscn
@@ -1,0 +1,70 @@
+[gd_scene load_steps=5 format=3 uid="uid://ci7p6xyvrqxxe"]
+
+[ext_resource type="Texture2D" uid="uid://d5r37te4v8qne" path="res://assets/ui/buildings/building_tile.png" id="1_fr0tu"]
+[ext_resource type="Texture2D" uid="uid://bx0nl05xwi7el" path="res://assets/ui/buildings/building_tile_button.png" id="2_sg6mu"]
+[ext_resource type="Script" path="res://scenes/ui/BuildingTile.gd" id="3_g7g2i"]
+
+[node name="BuildingTile" type="Control"]
+custom_minimum_size = Vector2(256, 256)
+layout_mode = 3
+anchors_preset = 0
+script = ExtResource("3_g7g2i")
+
+[node name="Background" type="TextureRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -16.0
+offset_top = -16.0
+offset_right = 16.0
+offset_bottom = 16.0
+texture = ExtResource("1_fr0tu")
+expand_mode = 1
+stretch_mode = 5
+
+[node name="ViewportContainer" type="SubViewportContainer" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 24.0
+offset_top = 24.0
+offset_right = -24.0
+offset_bottom = -72.0
+stretch = true
+
+[node name="SubViewport" type="SubViewport" parent="ViewportContainer"]
+render_target_update_mode = 3
+size = Vector2i(208, 184)
+transparent_bg = true
+usage = 1
+handle_input_locally = false
+
+[node name="PreviewRoot" type="Node3D" parent="ViewportContainer/SubViewport"]
+
+[node name="DirectionalLight3D" type="DirectionalLight3D" parent="ViewportContainer/SubViewport/PreviewRoot"]
+transform = Transform3D(-0.707107, 0.5, -0.5, 0, 0.707107, 0.707107, 0.707107, 0.5, -0.5, 0, 0, 0)
+shadow_enabled = true
+
+[node name="Camera3D" type="Camera3D" parent="ViewportContainer/SubViewport/PreviewRoot"]
+transform = Transform3D(0.894427, -0.358569, 0.267261, 0, 0.597614, 0.801785, -0.447214, -0.717138, 0.534522, 0, 1.5, 3)
+current = true
+fov = 40.0
+near = 0.1
+far = 50.0
+
+[node name="SpawnButton" type="TextureButton" parent="."]
+layout_mode = 1
+anchors_preset = 10
+anchor_left = 0.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_top = -64.0
+offset_right = 0.0
+offset_bottom = -16.0
+texture_normal = ExtResource("2_sg6mu")
+


### PR DESCRIPTION
## Summary
- add a building tile container to the kingdom UI that spawns buildings on demand
- create a reusable building tile scene with a 3D preview and spawn button for each structure

## Testing
- not run (Godot project)


------
https://chatgpt.com/codex/tasks/task_e_68d6581f1738832db4b9ffdb18070693