### PR TITLE
Adjust kingdom UI tile layout and icons

### DIFF
--- a/scenes/Kingdom.tscn
+++ b/scenes/Kingdom.tscn
@@ -37,11 +37,19 @@ texture_normal = ExtResource("1_cj0vx")
 texture_pressed = ExtResource("2_h5qp7")
 
 [node name="BuildingTileContainer" type="MarginContainer" parent="UI"]
-offset_left = 91.0
-offset_top = 405.0
-offset_right = 1571.0
-offset_bottom = 885.0
-scale = Vector2(0.654529, 0.458935)
+layout_mode = 1
+anchor_left = 0.0
+anchor_top = 0.75
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 32.0
+offset_top = 0.0
+offset_right = -32.0
+offset_bottom = -32.0
+theme_override_constants/margin_left = 24
+theme_override_constants/margin_top = 16
+theme_override_constants/margin_right = 24
+theme_override_constants/margin_bottom = 16
 
 [node name="TileList" type="HBoxContainer" parent="UI/BuildingTileContainer"]
 layout_mode = 2

--- a/scenes/ui/BuildingTile.gd
+++ b/scenes/ui/BuildingTile.gd
@@ -1,31 +1,39 @@
 extends Control
 
-@onready var preview_root: Node3D = $ViewportContainer/SubViewport/PreviewRoot
-@onready var spawn_button: TextureButton = $SpawnButton
+const BUILDING_ICON_PATHS := {
+	"Building1": "res://assets/kingdoms/kingdom1/icons/b1.png",
+	"Building2": "res://assets/kingdoms/kingdom1/icons/b2.png",
+	"Building3": "res://assets/kingdoms/kingdom1/icons/b3.png",
+	"Building4": "res://assets/kingdoms/kingdom1/icons/b4.png",
+	"Building5": "res://assets/kingdoms/kingdom1/icons/b5.png",
+}
+
+@onready var icon_rect: TextureRect = $Content/IconContainer/Icon
+@onready var spawn_button: TextureButton = $Content/SpawnButton
 
 var building_node: Node3D
-var preview_instance: Node3D = null
 
 func setup(building: Node3D) -> void:
 	building_node = building
 	if building_node:
 		building_node.visible = false
-	_populate_preview()
+	_update_icon()
 	if not spawn_button.pressed.is_connected(_on_spawn_pressed):
 		spawn_button.pressed.connect(_on_spawn_pressed)
 
 
-func _populate_preview() -> void:
-	if preview_instance:
-		preview_instance.queue_free()
-		preview_instance = null
-	if not building_node:
+func _update_icon() -> void:
+	if not icon_rect:
 		return
-	preview_instance = building_node.duplicate()
-	preview_instance.visible = true
-	preview_instance.transform = Transform3D.IDENTITY
-	preview_instance.scale = Vector3.ONE * 0.2
-	#preview_root.add_child(preview_instance)
+	var texture: Texture2D = null
+	if building_node:
+		var key := building_node.name
+		if BUILDING_ICON_PATHS.has(key):
+			var icon_path: String = BUILDING_ICON_PATHS[key]
+			if ResourceLoader.exists(icon_path, "Texture2D"):
+				texture = load(icon_path)
+	icon_rect.texture = texture
+	icon_rect.visible = texture != null
 
 
 func _on_spawn_pressed() -> void:

--- a/scenes/ui/BuildingTile.tscn
+++ b/scenes/ui/BuildingTile.tscn
@@ -5,10 +5,10 @@
 [ext_resource type="Script" uid="uid://ccjnacmftx4t5" path="res://scenes/ui/BuildingTile.gd" id="3_g7g2i"]
 
 [node name="BuildingTile" type="Control"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
 custom_minimum_size = Vector2(256, 256)
-layout_mode = 3
-anchors_preset = 0
-scale = Vector2(0.387281, 0.374161)
 script = ExtResource("3_g7g2i")
 
 [node name="Background" type="TextureRect" parent="."]
@@ -16,27 +16,40 @@ layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = -16.0
-offset_top = -16.0
-offset_right = 16.0
-offset_bottom = 16.0
 grow_horizontal = 2
 grow_vertical = 2
 texture = ExtResource("1_fr0tu")
 expand_mode = 1
 stretch_mode = 5
 
-[node name="SpawnButton" type="TextureButton" parent="."]
+[node name="Content" type="VBoxContainer" parent="."]
 layout_mode = 1
-anchors_preset = 12
-anchor_top = 1.0
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 69.0
-offset_top = -66.0
-offset_right = 365.0
-offset_bottom = 191.0
-grow_horizontal = 2
-grow_vertical = 0
-scale = Vector2(0.212533, 0.195205)
+offset_left = 16.0
+offset_top = 16.0
+offset_right = -16.0
+offset_bottom = -16.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 12
+
+[node name="IconContainer" type="CenterContainer" parent="Content"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Icon" type="TextureRect" parent="Content/IconContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+stretch_mode = 4
+
+[node name="SpawnButton" type="TextureButton" parent="Content"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 1
+custom_minimum_size = Vector2(0, 96)
+expand = true
 texture_normal = ExtResource("2_sg6mu")


### PR DESCRIPTION
## Summary
- anchor the kingdom building tile container to occupy the bottom quarter of the screen with consistent margins
- rebuild the building tile UI to use a centered icon with proper scaling and keep the spawn button within the layout
- load per-building icon textures from the kingdom icon folder instead of duplicating 3D previews

## Testing
- not run (Godot editor/runtime unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6e747270c832db4661f79a5d3a51a