### PR TITLE
Add kingdom configuration resources and scripts

### DIFF
--- a/assets/kingdoms/kingdom1/HomeBuilding.tres
+++ b/assets/kingdoms/kingdom1/HomeBuilding.tres
@@ -1,0 +1,25 @@
+[gd_resource type="Resource" load_steps=8 format=3]
+
+[ext_resource type="Script" path="res://scripts/config/BuildingConfig.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/config/BuildingLevelConfig.gd" id="2"]
+[ext_resource type="Texture2D" path="res://assets/models/kingdom1/hexagons_medieval.png" id="3"]
+[ext_resource type="PackedScene" path="res://assets/models/kingdom1/building_home_A_blue.gltf" id="4"]
+[ext_resource type="PackedScene" path="res://assets/models/kingdom1/building_home_B_blue.gltf" id="5"]
+
+[sub_resource type="Resource" id="Level1"]
+script = ExtResource("2")
+cost = 100
+icon = ExtResource("3")
+scene = ExtResource("4")
+
+[sub_resource type="Resource" id="Level2"]
+script = ExtResource("2")
+cost = 250
+icon = ExtResource("3")
+scene = ExtResource("5")
+
+[resource]
+script = ExtResource("1")
+display_name = "Homestead"
+spawn_point_path = NodePath("SpawnPoints/Home")
+levels = Array[Resource]([SubResource("Level1"), SubResource("Level2")])

--- a/assets/kingdoms/kingdom1/KingdomConfig.tres
+++ b/assets/kingdoms/kingdom1/KingdomConfig.tres
@@ -1,0 +1,13 @@
+[gd_resource type="Resource" load_steps=6 format=3]
+
+[ext_resource type="Script" path="res://scripts/config/KingdomConfig.gd" id="1"]
+[ext_resource type="PackedScene" path="res://scenes/environments/ForestKingdomEnvironment.tscn" id="2"]
+[ext_resource type="Resource" path="res://assets/kingdoms/kingdom1/HomeBuilding.tres" id="3"]
+[ext_resource type="Resource" path="res://assets/kingdoms/kingdom1/MarketBuilding.tres" id="4"]
+[ext_resource type="Resource" path="res://assets/kingdoms/kingdom1/TowerBuilding.tres" id="5"]
+
+[resource]
+script = ExtResource("1")
+kingdom_name = "Forest Kingdom"
+environment_scene = ExtResource("2")
+buildings = Array[Resource]([ExtResource("3"), ExtResource("4"), ExtResource("5")])

--- a/assets/kingdoms/kingdom1/MarketBuilding.tres
+++ b/assets/kingdoms/kingdom1/MarketBuilding.tres
@@ -1,0 +1,25 @@
+[gd_resource type="Resource" load_steps=8 format=3]
+
+[ext_resource type="Script" path="res://scripts/config/BuildingConfig.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/config/BuildingLevelConfig.gd" id="2"]
+[ext_resource type="Texture2D" path="res://assets/models/kingdom1/hexagons_medieval.png" id="3"]
+[ext_resource type="PackedScene" path="res://assets/models/kingdom1/building_market_blue.gltf" id="4"]
+[ext_resource type="PackedScene" path="res://assets/models/kingdom1/building_tavern_blue.gltf" id="5"]
+
+[sub_resource type="Resource" id="Level1"]
+script = ExtResource("2")
+cost = 180
+icon = ExtResource("3")
+scene = ExtResource("4")
+
+[sub_resource type="Resource" id="Level2"]
+script = ExtResource("2")
+cost = 420
+icon = ExtResource("3")
+scene = ExtResource("5")
+
+[resource]
+script = ExtResource("1")
+display_name = "Marketplace"
+spawn_point_path = NodePath("SpawnPoints/Market")
+levels = Array[Resource]([SubResource("Level1"), SubResource("Level2")])

--- a/assets/kingdoms/kingdom1/TowerBuilding.tres
+++ b/assets/kingdoms/kingdom1/TowerBuilding.tres
@@ -1,0 +1,32 @@
+[gd_resource type="Resource" load_steps=10 format=3]
+
+[ext_resource type="Script" path="res://scripts/config/BuildingConfig.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/config/BuildingLevelConfig.gd" id="2"]
+[ext_resource type="Texture2D" path="res://assets/models/kingdom1/hexagons_medieval.png" id="3"]
+[ext_resource type="PackedScene" path="res://assets/models/kingdom1/building_tower_A_blue.gltf" id="4"]
+[ext_resource type="PackedScene" path="res://assets/models/kingdom1/building_tower_B_blue.gltf" id="5"]
+[ext_resource type="PackedScene" path="res://assets/models/kingdom1/building_tower_catapult_blue.gltf" id="6"]
+
+[sub_resource type="Resource" id="Level1"]
+script = ExtResource("2")
+cost = 220
+icon = ExtResource("3")
+scene = ExtResource("4")
+
+[sub_resource type="Resource" id="Level2"]
+script = ExtResource("2")
+cost = 520
+icon = ExtResource("3")
+scene = ExtResource("5")
+
+[sub_resource type="Resource" id="Level3"]
+script = ExtResource("2")
+cost = 940
+icon = ExtResource("3")
+scene = ExtResource("6")
+
+[resource]
+script = ExtResource("1")
+display_name = "Watchtower"
+spawn_point_path = NodePath("SpawnPoints/Tower")
+levels = Array[Resource]([SubResource("Level1"), SubResource("Level2"), SubResource("Level3")])

--- a/scenes/environments/ForestKingdomEnvironment.tscn
+++ b/scenes/environments/ForestKingdomEnvironment.tscn
@@ -45,3 +45,14 @@ transform = Transform3D(4, 0, 0, 0, 3, 0, 0, 0, 4, -10, 3, -6)
 mesh = SubResource("BoxMesh_trunk")
 surface_material_override/0 = SubResource("StandardMaterial3D_trunk")
 
+[node name="SpawnPoints" type="Node3D" parent="."]
+
+[node name="Home" type="Node3D" parent="SpawnPoints"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -10, 0, -6)
+
+[node name="Market" type="Node3D" parent="SpawnPoints"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 6, 0, 8)
+
+[node name="Tower" type="Node3D" parent="SpawnPoints"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -10)
+

--- a/scripts/config/BuildingConfig.gd
+++ b/scripts/config/BuildingConfig.gd
@@ -1,0 +1,6 @@
+extends Resource
+class_name BuildingConfig
+
+@export var display_name: String = ""
+@export var spawn_point_path: NodePath
+@export var levels: Array[BuildingLevelConfig] = []

--- a/scripts/config/BuildingLevelConfig.gd
+++ b/scripts/config/BuildingLevelConfig.gd
@@ -1,0 +1,6 @@
+extends Resource
+class_name BuildingLevelConfig
+
+@export var cost: int = 0
+@export var icon: Texture2D
+@export var scene: PackedScene

--- a/scripts/config/KingdomConfig.gd
+++ b/scripts/config/KingdomConfig.gd
@@ -1,0 +1,6 @@
+extends Resource
+class_name KingdomConfig
+
+@export var kingdom_name: String = ""
+@export var environment_scene: PackedScene
+@export var buildings: Array[BuildingConfig] = []


### PR DESCRIPTION
## Summary
- add reusable Resource scripts for building levels, building definitions, and kingdoms
- create Forest kingdom configuration assets that reference existing building models and spawn nodes
- introduce spawn point nodes to the forest environment for placing configured buildings

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7f4e23bdc832d86b22bcb9de1175e