### PR TITLE
Refactor kingdom setup to use config-driven environments

### DIFF
--- a/assets/kingdoms/desert/KingdomConfig.tres
+++ b/assets/kingdoms/desert/KingdomConfig.tres
@@ -1,0 +1,10 @@
+[gd_resource type="Resource" load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/config/KingdomConfig.gd" id="1"]
+[ext_resource type="PackedScene" path="res://scenes/environments/DesertKingdomEnvironment.tscn" id="2"]
+
+[resource]
+script = ExtResource("1")
+kingdom_name = "Desert Kingdom"
+environment_scene = ExtResource("2")
+buildings = Array[Resource]([])

--- a/scenes/KingdomBase.tscn
+++ b/scenes/KingdomBase.tscn
@@ -3,11 +3,11 @@
 [ext_resource type="Texture2D" uid="uid://cl282gwrr1o4a" path="res://assets/ui/buttons/play.png" id="1_cj0vx"]
 [ext_resource type="Script" uid="uid://dtdur3vgsfwc5" path="res://scenes/Kingdom.gd" id="1_h5qp7"]
 [ext_resource type="Texture2D" uid="uid://lm30aibs7ft5" path="res://assets/ui/buttons/play_pressed.png" id="2_h5qp7"]
-[ext_resource type="PackedScene" uid="uid://bjo4ee8nf0157" path="res://scenes/environments/KingdomEnvironment.tscn" id="3_lqhuc"]
+[ext_resource type="Resource" path="res://assets/kingdoms/kingdom1/KingdomConfig.tres" id="3_kwx2l"]
 
 [node name="Kingdom" type="Node3D"]
 script = ExtResource("1_h5qp7")
-environment_scene = ExtResource("3_lqhuc")
+kingdom_config = ExtResource("3_kwx2l")
 
 [node name="UI" type="CanvasLayer" parent="."]
 

--- a/scenes/kingdoms/DesertKingdom.tscn
+++ b/scenes/kingdoms/DesertKingdom.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=2 format=3 inherits="res://scenes/KingdomBase.tscn"]
 
-[ext_resource type="PackedScene" path="res://scenes/environments/DesertKingdomEnvironment.tscn" id="1_environment"]
+[ext_resource type="Resource" path="res://assets/kingdoms/desert/KingdomConfig.tres" id="1_kingdom_config"]
 
 [node name="Kingdom" parent="."]
-environment_scene = ExtResource("1_environment")
+kingdom_config = ExtResource("1_kingdom_config")
 

--- a/scenes/kingdoms/ForestKingdom.tscn
+++ b/scenes/kingdoms/ForestKingdom.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=2 format=3 inherits="res://scenes/KingdomBase.tscn"]
 
-[ext_resource type="PackedScene" path="res://scenes/environments/ForestKingdomEnvironment.tscn" id="1_environment"]
+[ext_resource type="Resource" path="res://assets/kingdoms/kingdom1/KingdomConfig.tres" id="1_kingdom_config"]
 
 [node name="Kingdom" parent="."]
-environment_scene = ExtResource("1_environment")
+kingdom_config = ExtResource("1_kingdom_config")
 

--- a/scenes/ui/BuildingTile.gd
+++ b/scenes/ui/BuildingTile.gd
@@ -1,43 +1,64 @@
 extends Control
 
-const BUILDING_ICON_PATHS := {
-	"Building1": "res://assets/kingdoms/kingdom1/icons/b1.png",
-	"Building2": "res://assets/kingdoms/kingdom1/icons/b2.png",
-	"Building3": "res://assets/kingdoms/kingdom1/icons/b3.png",
-	"Building4": "res://assets/kingdoms/kingdom1/icons/b4.png",
-	"Building5": "res://assets/kingdoms/kingdom1/icons/b5.png",
-}
-
 @onready var icon_rect: TextureRect = $Content/IconContainer/Icon
 @onready var spawn_button: TextureButton = $Content/SpawnButton
 
-var building_node: Node3D
+var building_config: BuildingConfig
+var spawn_point: Node3D
+var active_building: Node3D
 
-func setup(building: Node3D) -> void:
-	building_node = building
-	if building_node:
-		building_node.visible = false
-	_update_icon()
-	if not spawn_button.pressed.is_connected(_on_spawn_pressed):
-		spawn_button.pressed.connect(_on_spawn_pressed)
+func setup(config: BuildingConfig, spawn: Node3D) -> void:
+        building_config = config
+        spawn_point = spawn
+        if active_building:
+                active_building.queue_free()
+                active_building = null
+        _update_icon()
+        spawn_button.disabled = not _can_spawn()
+        spawn_button.hint_tooltip = building_config.display_name if building_config else ""
+        if not spawn_button.pressed.is_connected(_on_spawn_pressed):
+                spawn_button.pressed.connect(_on_spawn_pressed)
 
 
 func _update_icon() -> void:
-	if not icon_rect:
-		return
-	var texture: Texture2D = null
-	if building_node:
-		var key := building_node.name
-		if BUILDING_ICON_PATHS.has(key):
-			var icon_path: String = BUILDING_ICON_PATHS[key]
-			if ResourceLoader.exists(icon_path, "Texture2D"):
-				texture = load(icon_path)
-	icon_rect.texture = texture
-	icon_rect.visible = texture != null
+        if not icon_rect:
+                return
+
+        var texture: Texture2D = null
+
+        if building_config:
+                for level_config in building_config.levels:
+                        if level_config and level_config.icon:
+                                texture = level_config.icon
+                                break
+
+        icon_rect.texture = texture
+        icon_rect.visible = texture != null
+
+
+func _can_spawn() -> bool:
+        return building_config != null and spawn_point != null and building_config.levels.size() > 0
 
 
 func _on_spawn_pressed() -> void:
-	if not building_node:
-		return
-	building_node.visible = true
-	spawn_button.disabled = true
+        if not _can_spawn():
+                push_warning("Cannot spawn building without a valid config, spawn point, and level definition.")
+                return
+
+        if active_building:
+                return
+
+        var level_config: BuildingLevelConfig = null
+
+        for level in building_config.levels:
+                if level and level.scene:
+                        level_config = level
+                        break
+
+        if not level_config:
+                push_warning("No valid scene found for building '%s'." % building_config.display_name)
+                return
+
+        active_building = level_config.scene.instantiate()
+        spawn_point.add_child(active_building)
+        spawn_button.disabled = true


### PR DESCRIPTION
## Summary
- replace the kingdom scene export with a KingdomConfig resource and instantiate environments from its environment scene
- rebuild building tile creation from config entries and spawn nodes, passing the config data into each tile
- add a desert kingdom config resource and update kingdom scenes to reference the new configs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d928c35084832d84dd23e28ace1c91