### PR TITLE
Add building tile config-driven spawn and upgrade logic

### DIFF
--- a/scenes/Kingdom.gd
+++ b/scenes/Kingdom.gd
@@ -56,21 +56,9 @@ func _create_building_tiles() -> void:
                 if building_config == null:
                         continue
 
-                var spawn_point: Node3D = null
-
-                if not building_config.spawn_point_path.is_empty():
-                        spawn_point = active_environment.get_node_or_null(building_config.spawn_point_path)
-                        if not spawn_point:
-                                push_warning("Spawn point '%s' not found for building '%s'." % [
-                                        String(building_config.spawn_point_path),
-                                        building_config.display_name
-                                ])
-                else:
-                        push_warning("Building '%s' is missing a spawn point path." % building_config.display_name)
-
                 var tile := BUILDING_TILE_SCENE.instantiate()
                 building_tile_container.add_child(tile)
-                tile.setup(building_config, spawn_point)
+                tile.setup(building_config, active_environment)
 		
 	
 func _on_play_pressed() -> void:

--- a/scenes/ui/BuildingTile.gd
+++ b/scenes/ui/BuildingTile.gd
@@ -1,64 +1,182 @@
 extends Control
 
 @onready var icon_rect: TextureRect = $Content/IconContainer/Icon
+@onready var name_label: Label = $Content/NameLabel
+@onready var cost_label: Label = $Content/CostLabel
 @onready var spawn_button: TextureButton = $Content/SpawnButton
+@onready var spawn_label: Label = $Content/SpawnButton/Label
 
 var building_config: BuildingConfig
+var environment_root: Node
 var spawn_point: Node3D
 var active_building: Node3D
+var active_level_index: int = -1
+var placeholders_hidden: bool = false
+var spawn_warning_emitted: bool = false
 
-func setup(config: BuildingConfig, spawn: Node3D) -> void:
-        building_config = config
-        spawn_point = spawn
-        if active_building:
-                active_building.queue_free()
-                active_building = null
-        _update_icon()
-        spawn_button.disabled = not _can_spawn()
+func setup(config: BuildingConfig, environment: Node = null, spawn_override: Node3D = null) -> void:
+    building_config = config
+    environment_root = environment
+    spawn_point = spawn_override
+    active_level_index = -1
+    placeholders_hidden = false
+    spawn_warning_emitted = false
+
+    if active_building and is_instance_valid(active_building):
+        active_building.queue_free()
+        active_building = null
+
+    _ensure_spawn_point()
+    _update_ui()
+
+    if spawn_button:
         spawn_button.hint_tooltip = building_config.display_name if building_config else ""
         if not spawn_button.pressed.is_connected(_on_spawn_pressed):
-                spawn_button.pressed.connect(_on_spawn_pressed)
+            spawn_button.pressed.connect(_on_spawn_pressed)
 
 
-func _update_icon() -> void:
-        if not icon_rect:
-                return
+func _ensure_spawn_point() -> void:
+    if spawn_point:
+        return
 
-        var texture: Texture2D = null
+    if not building_config:
+        return
 
-        if building_config:
-                for level_config in building_config.levels:
-                        if level_config and level_config.icon:
-                                texture = level_config.icon
-                                break
+    if not environment_root:
+        return
 
-        icon_rect.texture = texture
-        icon_rect.visible = texture != null
+    if building_config.spawn_point_path.is_empty():
+        if not spawn_warning_emitted:
+            push_warning("Building '%s' is missing a spawn point path." % building_config.display_name)
+            spawn_warning_emitted = true
+        return
+
+    var found := environment_root.get_node_or_null(building_config.spawn_point_path)
+    if found and found is Node3D:
+        spawn_point = found
+    else:
+        if not spawn_warning_emitted:
+            push_warning("Spawn point '%s' not found for building '%s'." % [
+                String(building_config.spawn_point_path),
+                building_config.display_name
+            ])
+            spawn_warning_emitted = true
+
+
+func _update_ui() -> void:
+    _ensure_spawn_point()
+
+    var next_level_index := active_level_index + 1
+    var next_level := _get_level_config(next_level_index)
+    var display_level := next_level if next_level else _get_level_config(active_level_index)
+
+    _update_icon(display_level)
+
+    if name_label:
+        name_label.text = building_config.display_name if building_config else ""
+
+    if cost_label:
+        if next_level:
+            cost_label.text = "Cost: %d" % next_level.cost
+        elif building_config:
+            cost_label.text = "Max level reached"
+        else:
+            cost_label.text = ""
+
+    if spawn_label:
+        if next_level:
+            spawn_label.text = "Build" if active_level_index < 0 else "Upgrade"
+        elif building_config:
+            spawn_label.text = "Max Level"
+        else:
+            spawn_label.text = ""
+
+    if spawn_button:
+        spawn_button.disabled = not _can_spawn()
+
+
+func _update_icon(level_config: BuildingLevelConfig) -> void:
+    if not icon_rect:
+        return
+
+    var texture: Texture2D = null
+
+    if level_config and level_config.icon:
+        texture = level_config.icon
+    elif building_config:
+        for config_level in building_config.levels:
+            if config_level and config_level.icon:
+                texture = config_level.icon
+                break
+
+    icon_rect.texture = texture
+    icon_rect.visible = texture != null
+
+
+func _get_level_config(index: int) -> BuildingLevelConfig:
+    if not building_config:
+        return null
+
+    if index < 0 or index >= building_config.levels.size():
+        return null
+
+    var level = building_config.levels[index]
+    return level if level is BuildingLevelConfig else null
 
 
 func _can_spawn() -> bool:
-        return building_config != null and spawn_point != null and building_config.levels.size() > 0
+    _ensure_spawn_point()
+    return building_config != null and spawn_point != null and _get_level_config(active_level_index + 1) != null
 
 
 func _on_spawn_pressed() -> void:
-        if not _can_spawn():
-                push_warning("Cannot spawn building without a valid config, spawn point, and level definition.")
-                return
+    if not _can_spawn():
+        push_warning("Cannot spawn building without a valid config, spawn point, and level definition.")
+        return
 
-        if active_building:
-                return
+    var level_index := active_level_index + 1
+    var level_config := _get_level_config(level_index)
+    if not level_config:
+        push_warning("No valid scene found for building '%s'." % (building_config.display_name if building_config else ""))
+        return
 
-        var level_config: BuildingLevelConfig = null
+    if not level_config.scene:
+        push_warning("Level %d for building '%s' is missing a scene." % [level_index + 1, building_config.display_name])
+        return
 
-        for level in building_config.levels:
-                if level and level.scene:
-                        level_config = level
-                        break
+    var instance := level_config.scene.instantiate()
+    if not instance:
+        push_warning("Failed to instance scene for building '%s'." % building_config.display_name)
+        return
 
-        if not level_config:
-                push_warning("No valid scene found for building '%s'." % building_config.display_name)
-                return
+    _clear_placeholders()
 
-        active_building = level_config.scene.instantiate()
-        spawn_point.add_child(active_building)
-        spawn_button.disabled = true
+    if active_building and is_instance_valid(active_building):
+        active_building.queue_free()
+
+    spawn_point.add_child(instance)
+    active_building = instance
+    active_level_index = level_index
+
+    _update_ui()
+
+
+func _clear_placeholders() -> void:
+    if placeholders_hidden or not spawn_point:
+        return
+
+    for child in spawn_point.get_children():
+        if child == active_building:
+            continue
+
+        if child is Node3D:
+            child.visible = false
+
+    placeholders_hidden = true
+
+func get_active_level_config() -> BuildingLevelConfig:
+    return _get_level_config(active_level_index)
+
+
+func get_next_level_config() -> BuildingLevelConfig:
+    return _get_level_config(active_level_index + 1)

--- a/scenes/ui/BuildingTile.tscn
+++ b/scenes/ui/BuildingTile.tscn
@@ -53,9 +53,31 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 stretch_mode = 4
 
+[node name="NameLabel" type="Label" parent="Content"]
+layout_mode = 2
+size_flags_horizontal = 3
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="CostLabel" type="Label" parent="Content"]
+layout_mode = 2
+size_flags_horizontal = 3
+horizontal_alignment = 1
+vertical_alignment = 1
+
 [node name="SpawnButton" type="TextureButton" parent="Content"]
 custom_minimum_size = Vector2(0, 96)
 layout_mode = 2
 size_flags_horizontal = 3
 texture_normal = ExtResource("2_sg6mu")
 ignore_texture_size = true
+
+[node name="Label" type="Label" parent="Content/SpawnButton"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+horizontal_alignment = 1
+vertical_alignment = 1


### PR DESCRIPTION
## Summary
- update the building tile script and scene to display name/cost from the building configuration and handle spawn/upgrade state
- resolve spawn points from the active environment when wiring tiles in the kingdom scene so tiles can instantiate configured levels

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d97837a570832dbf7c6887ce6ac9cf