### PR TITLE
Refine kingdom environments for dynamic spawns

### DIFF
--- a/scenes/KingdomBase.tscn
+++ b/scenes/KingdomBase.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=5 format=3 uid="uid://fwfch7tbk6j4"]
+[gd_scene load_steps=4 format=3 uid="uid://fwfch7tbk6j4"]
 
 [ext_resource type="Texture2D" uid="uid://cl282gwrr1o4a" path="res://assets/ui/buttons/play.png" id="1_cj0vx"]
 [ext_resource type="Script" uid="uid://dtdur3vgsfwc5" path="res://scenes/Kingdom.gd" id="1_h5qp7"]

--- a/scenes/environments/DesertKingdomEnvironment.tscn
+++ b/scenes/environments/DesertKingdomEnvironment.tscn
@@ -1,22 +1,10 @@
-[gd_scene load_steps=8 format=3]
+[gd_scene load_steps=3 format=3]
 
 [sub_resource type="PlaneMesh" id="PlaneMesh_ground"]
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_sand"]
 albedo_color = Color(0.858824, 0.745098, 0.462745, 1)
 roughness = 0.7
-
-[sub_resource type="DirectionalLight3D" id="DirectionalLight3D_sun"]
-light_energy = 1.3
-shadow_enabled = true
-
-[sub_resource type="BoxMesh" id="BoxMesh_ruin"]
-
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_stone"]
-albedo_color = Color(0.780392, 0.682353, 0.580392, 1)
-roughness = 0.4
-
-[sub_resource type="CylinderMesh" id="CylinderMesh_obelisk"]
 
 [node name="DesertKingdomEnvironment" type="Node3D"]
 
@@ -34,13 +22,14 @@ shadow_enabled = true
 transform = Transform3D(-0.543254, 0.668129, -0.508407, 0.000334382, 0.60573, 0.79567, 0.839568, 0.432081, -0.329289, -36.7838, 38.8347, -21.1955)
 fov = 54.9
 
-[node name="BuildingRuin" type="MeshInstance3D" parent="."]
-transform = Transform3D(6, 0, 0, 0, 4, 0, 0, 0, 6, -12, 2, 6)
-mesh = SubResource("BoxMesh_ruin")
-surface_material_override/0 = SubResource("StandardMaterial3D_stone")
+[node name="SpawnPoints" type="Node3D" parent="."]
 
-[node name="BuildingObelisk" type="MeshInstance3D" parent="."]
-transform = Transform3D(2, 0, 0, 0, 12, 0, 0, 0, 2, 8, 6, -10)
-mesh = SubResource("CylinderMesh_obelisk")
-surface_material_override/0 = SubResource("StandardMaterial3D_stone")
+[node name="Home" type="Node3D" parent="SpawnPoints"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -12, 0, 6)
+
+[node name="Market" type="Node3D" parent="SpawnPoints"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 8, 0, -10)
+
+[node name="Tower" type="Node3D" parent="SpawnPoints"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
 

--- a/scenes/environments/ForestKingdomEnvironment.tscn
+++ b/scenes/environments/ForestKingdomEnvironment.tscn
@@ -1,17 +1,10 @@
-[gd_scene load_steps=6 format=3 uid="uid://x2ye7o7nd6mm"]
+[gd_scene load_steps=3 format=3 uid="uid://x2ye7o7nd6mm"]
 
 [sub_resource type="PlaneMesh" id="PlaneMesh_ground"]
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_ground"]
 albedo_color = Color(0.184314, 0.486275, 0.239216, 1)
 roughness = 0.3
-
-[sub_resource type="BoxMesh" id="BoxMesh_trunk"]
-
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_trunk"]
-albedo_color = Color(0.278431, 0.129412, 0.0588235, 1)
-
-[sub_resource type="SphereMesh" id="SphereMesh_foliage"]
 
 [node name="ForestKingdomEnvironment" type="Node3D"]
 
@@ -27,22 +20,6 @@ shadow_enabled = true
 [node name="IsoCamera" type="Camera3D" parent="."]
 transform = Transform3D(-0.543254, 0.668129, -0.508407, 0.000334382, 0.60573, 0.79567, 0.839568, 0.432081, -0.329289, -36.7838, 38.8347, -21.1955)
 fov = 54.9
-
-[node name="BuildingTree" type="Node3D" parent="."]
-
-[node name="BuildingTrunk" type="MeshInstance3D" parent="BuildingTree"]
-transform = Transform3D(1, 0, 0, 0, 6, 0, 0, 0, 1, 0, 3, 0)
-mesh = SubResource("BoxMesh_trunk")
-surface_material_override/0 = SubResource("StandardMaterial3D_trunk")
-
-[node name="BuildingCanopy" type="MeshInstance3D" parent="BuildingTree"]
-transform = Transform3D(6, 0, 0, 0, 4, 0, 0, 0, 6, 0, 8, 0)
-mesh = SubResource("SphereMesh_foliage")
-
-[node name="BuildingCabin" type="MeshInstance3D" parent="."]
-transform = Transform3D(4, 0, 0, 0, 3, 0, 0, 0, 4, -10, 3, -6)
-mesh = SubResource("BoxMesh_trunk")
-surface_material_override/0 = SubResource("StandardMaterial3D_trunk")
 
 [node name="SpawnPoints" type="Node3D" parent="."]
 

--- a/scenes/environments/KingdomEnvironment.tscn
+++ b/scenes/environments/KingdomEnvironment.tscn
@@ -1,22 +1,9 @@
-[gd_scene load_steps=9 format=3 uid="uid://bjo4ee8nf0157"]
+[gd_scene load_steps=3 format=3 uid="uid://bjo4ee8nf0157"]
 
 [sub_resource type="PlaneMesh" id="PlaneMesh_h5qp7"]
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_fl14s"]
 albedo_color = Color(1.83859e-05, 0.656866, 0.101932, 1)
-
-[sub_resource type="BoxMesh" id="BoxMesh_ow33k"]
-
-[sub_resource type="BoxMesh" id="BoxMesh_7rbdv"]
-
-[sub_resource type="BoxMesh" id="BoxMesh_3e21f"]
-
-[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_h5qp7"]
-albedo_color = Color(0.544974, 0.544974, 0.544974, 1)
-
-[sub_resource type="CylinderMesh" id="CylinderMesh_plnuo"]
-
-[sub_resource type="PrismMesh" id="PrismMesh_je0v2"]
 
 [node name="KingdomEnvironment" type="Node3D"]
 
@@ -33,23 +20,13 @@ shadow_enabled = true
 transform = Transform3D(-0.543254, 0.668129, -0.508407, 0.000334382, 0.60573, 0.79567, 0.839568, 0.432081, -0.329289, -36.7838, 38.8347, -21.1955)
 fov = 54.9
 
-[node name="Building1" type="MeshInstance3D" parent="."]
-transform = Transform3D(4, 0, 0, 0, 4, 0, 0, 0, 4, -12.8805, 2, 8.17621)
-mesh = SubResource("BoxMesh_ow33k")
+[node name="SpawnPoints" type="Node3D" parent="."]
 
-[node name="Building2" type="MeshInstance3D" parent="."]
-transform = Transform3D(4.36378, 0, 0, 0, 9.2, 0, 0, 0, 3.90321, -3.37805, 4.5, -10.8704)
-mesh = SubResource("BoxMesh_7rbdv")
+[node name="Home" type="Node3D" parent="SpawnPoints"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -12.8805, 0, 8.17621)
 
-[node name="Building3" type="MeshInstance3D" parent="."]
-transform = Transform3D(-1.1941e-07, 0, 5.73349, 0, 9.23908, 0, -2.73178, 0, -2.50619e-07, -20.959, 4.61938, -1.21265)
-mesh = SubResource("BoxMesh_3e21f")
-surface_material_override/0 = SubResource("StandardMaterial3D_h5qp7")
+[node name="Market" type="Node3D" parent="SpawnPoints"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3.37805, 0, -10.8704)
 
-[node name="Building4" type="MeshInstance3D" parent="."]
-transform = Transform3D(5, 0, 0, 0, 5, 0, 0, 0, 5, 0, 4.99158, 5.95514)
-mesh = SubResource("CylinderMesh_plnuo")
-
-[node name="Building5" type="MeshInstance3D" parent="."]
-transform = Transform3D(4, 0, 0, 0, 4, 0, 0, 0, 4, 9.53284, 1.69214, 0)
-mesh = SubResource("PrismMesh_je0v2")
+[node name="Tower" type="Node3D" parent="SpawnPoints"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 9.53284, 0, 0)


### PR DESCRIPTION
## Summary
- update KingdomBase to rely on the exported KingdomConfig resource without the obsolete environment reference
- add explicit spawn point nodes to each kingdom environment scene
- remove baked-in placeholder meshes now that buildings are spawned dynamically

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9985bf9ac832d8aae356932390395