### PR TITLE
Fix kingdom scene root overrides

### DIFF
--- a/scenes/kingdoms/DesertKingdom.tscn
+++ b/scenes/kingdoms/DesertKingdom.tscn
@@ -2,6 +2,6 @@
 
 [ext_resource type="Resource" path="res://assets/kingdoms/desert/KingdomConfig.tres" id="1_kingdom_config"]
 
-[node name="Kingdom" parent="."]
+[node name="Kingdom"]
 kingdom_config = ExtResource("1_kingdom_config")
 

--- a/scenes/kingdoms/ForestKingdom.tscn
+++ b/scenes/kingdoms/ForestKingdom.tscn
@@ -2,6 +2,6 @@
 
 [ext_resource type="Resource" path="res://assets/kingdoms/kingdom1/KingdomConfig.tres" id="1_kingdom_config"]
 
-[node name="Kingdom" parent="."]
+[node name="Kingdom"]
 kingdom_config = ExtResource("1_kingdom_config")
 


### PR DESCRIPTION
## Summary
- remove explicit parent overrides from the Forest and Desert kingdom scenes so the inherited root is used correctly

## Testing
- not run (Godot editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68da1cc89690832dbbd6283a68feba2d