### PR TITLE
Update kingdom scenes to inherit from base

### DIFF
--- a/scenes/kingdoms/DesertKingdom.tscn
+++ b/scenes/kingdoms/DesertKingdom.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=2 format=3 inherits="res://scenes/KingdomBase.tscn"]
+[gd_scene load_steps=2 format=3 base="res://scenes/KingdomBase.tscn" uid="uid://dqqlmkbt2d4l"]
 
 [ext_resource type="Resource" path="res://assets/kingdoms/desert/KingdomConfig.tres" id="1_kingdom_config"]
 

--- a/scenes/kingdoms/ForestKingdom.tscn
+++ b/scenes/kingdoms/ForestKingdom.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=2 format=3 inherits="res://scenes/KingdomBase.tscn"]
+[gd_scene load_steps=2 format=3 base="res://scenes/KingdomBase.tscn" uid="uid://bh3msf1q0g6d"]
 
 [ext_resource type="Resource" path="res://assets/kingdoms/kingdom1/KingdomConfig.tres" id="1_kingdom_config"]
 


### PR DESCRIPTION
## Summary
- regenerate the Forest and Desert kingdom scenes so they inherit from `KingdomBase` using the new `base` scene header format

## Testing
- `godot4 --headless --check-only project.godot` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da46496c0c832d9a311cc5e511292e