### PR TITLE
feat: add bespoke kingdom building art assets

### DIFF
--- a/assets/icons/kingdom1/home_level1.svg
+++ b/assets/icons/kingdom1/home_level1.svg
@@ -1,0 +1,5 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <rect width='256' height='256' fill='#f4c542'/>
+  <rect x='20' y='20' width='216' height='216' fill='none' stroke='white' stroke-width='10' rx='24' ry='24'/>
+  <text x='128' y='136' font-family='DejaVu Sans, Arial, sans-serif' font-size='36' fill='white' text-anchor='middle'>Homestead I</text>
+</svg>

--- a/assets/icons/kingdom1/home_level2.svg
+++ b/assets/icons/kingdom1/home_level2.svg
@@ -1,0 +1,5 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <rect width='256' height='256' fill='#d48c28'/>
+  <rect x='20' y='20' width='216' height='216' fill='none' stroke='white' stroke-width='10' rx='24' ry='24'/>
+  <text x='128' y='136' font-family='DejaVu Sans, Arial, sans-serif' font-size='36' fill='white' text-anchor='middle'>Homestead II</text>
+</svg>

--- a/assets/icons/kingdom1/market_level1.svg
+++ b/assets/icons/kingdom1/market_level1.svg
@@ -1,0 +1,5 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <rect width='256' height='256' fill='#4caf50'/>
+  <rect x='20' y='20' width='216' height='216' fill='none' stroke='white' stroke-width='10' rx='24' ry='24'/>
+  <text x='128' y='136' font-family='DejaVu Sans, Arial, sans-serif' font-size='36' fill='white' text-anchor='middle'>Market I</text>
+</svg>

--- a/assets/icons/kingdom1/market_level2.svg
+++ b/assets/icons/kingdom1/market_level2.svg
@@ -1,0 +1,5 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <rect width='256' height='256' fill='#2e7d32'/>
+  <rect x='20' y='20' width='216' height='216' fill='none' stroke='white' stroke-width='10' rx='24' ry='24'/>
+  <text x='128' y='136' font-family='DejaVu Sans, Arial, sans-serif' font-size='36' fill='white' text-anchor='middle'>Market II</text>
+</svg>

--- a/assets/icons/kingdom1/tower_level1.svg
+++ b/assets/icons/kingdom1/tower_level1.svg
@@ -1,0 +1,5 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <rect width='256' height='256' fill='#64b5f6'/>
+  <rect x='20' y='20' width='216' height='216' fill='none' stroke='white' stroke-width='10' rx='24' ry='24'/>
+  <text x='128' y='136' font-family='DejaVu Sans, Arial, sans-serif' font-size='36' fill='white' text-anchor='middle'>Tower I</text>
+</svg>

--- a/assets/icons/kingdom1/tower_level2.svg
+++ b/assets/icons/kingdom1/tower_level2.svg
@@ -1,0 +1,5 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <rect width='256' height='256' fill='#1976d2'/>
+  <rect x='20' y='20' width='216' height='216' fill='none' stroke='white' stroke-width='10' rx='24' ry='24'/>
+  <text x='128' y='136' font-family='DejaVu Sans, Arial, sans-serif' font-size='36' fill='white' text-anchor='middle'>Tower II</text>
+</svg>

--- a/assets/icons/kingdom1/tower_level3.svg
+++ b/assets/icons/kingdom1/tower_level3.svg
@@ -1,0 +1,5 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='256' height='256' viewBox='0 0 256 256'>
+  <rect width='256' height='256' fill='#0d47a1'/>
+  <rect x='20' y='20' width='216' height='216' fill='none' stroke='white' stroke-width='10' rx='24' ry='24'/>
+  <text x='128' y='136' font-family='DejaVu Sans, Arial, sans-serif' font-size='36' fill='white' text-anchor='middle'>Tower III</text>
+</svg>

--- a/assets/kingdoms/kingdom1/HomeBuilding.tres
+++ b/assets/kingdoms/kingdom1/HomeBuilding.tres
@@ -1,22 +1,23 @@
-[gd_resource type="Resource" script_class="BuildingConfig" load_steps=8 format=3 uid="uid://bbuwmy7ohjj8m"]
+[gd_resource type="Resource" script_class="BuildingConfig" load_steps=9 format=3 uid="uid://bbuwmy7ohjj8m"]
 
 [ext_resource type="Script" uid="uid://g3l4vfe6x8e" path="res://scripts/config/BuildingConfig.gd" id="1"]
 [ext_resource type="Script" uid="uid://blcm4k05x3wip" path="res://scripts/config/BuildingLevelConfig.gd" id="2"]
-[ext_resource type="Texture2D" uid="uid://df8os0pwl3yk6" path="res://assets/models/kingdom1/hexagons_medieval.png" id="3"]
-[ext_resource type="PackedScene" uid="uid://c3m168gd4pxpc" path="res://assets/models/kingdom1/building_home_A_blue.gltf" id="4"]
-[ext_resource type="PackedScene" uid="uid://bdovroy541o7y" path="res://assets/models/kingdom1/building_home_B_blue.gltf" id="5"]
+[ext_resource type="Texture2D" path="res://assets/icons/kingdom1/home_level1.svg" id="3"]
+[ext_resource type="Texture2D" path="res://assets/icons/kingdom1/home_level2.svg" id="4"]
+[ext_resource type="PackedScene" path="res://assets/models/kingdom1/home_level1.tscn" id="5"]
+[ext_resource type="PackedScene" path="res://assets/models/kingdom1/home_level2.tscn" id="6"]
 
 [sub_resource type="Resource" id="Level1"]
 script = ExtResource("2")
 cost = 100
 icon = ExtResource("3")
-scene = ExtResource("4")
+scene = ExtResource("5")
 
 [sub_resource type="Resource" id="Level2"]
 script = ExtResource("2")
 cost = 250
-icon = ExtResource("3")
-scene = ExtResource("5")
+icon = ExtResource("4")
+scene = ExtResource("6")
 
 [resource]
 script = ExtResource("1")

--- a/assets/kingdoms/kingdom1/MarketBuilding.tres
+++ b/assets/kingdoms/kingdom1/MarketBuilding.tres
@@ -1,22 +1,23 @@
-[gd_resource type="Resource" script_class="BuildingConfig" load_steps=8 format=3 uid="uid://cwr8r1kxfuscn"]
+[gd_resource type="Resource" script_class="BuildingConfig" load_steps=9 format=3 uid="uid://cwr8r1kxfuscn"]
 
 [ext_resource type="Script" uid="uid://g3l4vfe6x8e" path="res://scripts/config/BuildingConfig.gd" id="1"]
 [ext_resource type="Script" uid="uid://blcm4k05x3wip" path="res://scripts/config/BuildingLevelConfig.gd" id="2"]
-[ext_resource type="Texture2D" uid="uid://df8os0pwl3yk6" path="res://assets/models/kingdom1/hexagons_medieval.png" id="3"]
-[ext_resource type="PackedScene" uid="uid://dd02llgnjip0w" path="res://assets/models/kingdom1/building_market_blue.gltf" id="4"]
-[ext_resource type="PackedScene" uid="uid://dxo2d5wgmhrm8" path="res://assets/models/kingdom1/building_tavern_blue.gltf" id="5"]
+[ext_resource type="Texture2D" path="res://assets/icons/kingdom1/market_level1.svg" id="3"]
+[ext_resource type="Texture2D" path="res://assets/icons/kingdom1/market_level2.svg" id="4"]
+[ext_resource type="PackedScene" path="res://assets/models/kingdom1/market_level1.tscn" id="5"]
+[ext_resource type="PackedScene" path="res://assets/models/kingdom1/market_level2.tscn" id="6"]
 
 [sub_resource type="Resource" id="Level1"]
 script = ExtResource("2")
 cost = 180
 icon = ExtResource("3")
-scene = ExtResource("4")
+scene = ExtResource("5")
 
 [sub_resource type="Resource" id="Level2"]
 script = ExtResource("2")
 cost = 420
-icon = ExtResource("3")
-scene = ExtResource("5")
+icon = ExtResource("4")
+scene = ExtResource("6")
 
 [resource]
 script = ExtResource("1")

--- a/assets/kingdoms/kingdom1/TowerBuilding.tres
+++ b/assets/kingdoms/kingdom1/TowerBuilding.tres
@@ -1,29 +1,31 @@
-[gd_resource type="Resource" script_class="BuildingConfig" load_steps=10 format=3 uid="uid://6g5igc0q1dh2"]
+[gd_resource type="Resource" script_class="BuildingConfig" load_steps=12 format=3 uid="uid://6g5igc0q1dh2"]
 
 [ext_resource type="Script" uid="uid://g3l4vfe6x8e" path="res://scripts/config/BuildingConfig.gd" id="1"]
 [ext_resource type="Script" uid="uid://blcm4k05x3wip" path="res://scripts/config/BuildingLevelConfig.gd" id="2"]
-[ext_resource type="Texture2D" uid="uid://df8os0pwl3yk6" path="res://assets/models/kingdom1/hexagons_medieval.png" id="3"]
-[ext_resource type="PackedScene" uid="uid://payk04jejjs6" path="res://assets/models/kingdom1/building_tower_A_blue.gltf" id="4"]
-[ext_resource type="PackedScene" uid="uid://cxot4m306aiao" path="res://assets/models/kingdom1/building_tower_B_blue.gltf" id="5"]
-[ext_resource type="PackedScene" uid="uid://b6ig5rse6thoh" path="res://assets/models/kingdom1/building_tower_catapult_blue.gltf" id="6"]
+[ext_resource type="Texture2D" path="res://assets/icons/kingdom1/tower_level1.svg" id="3"]
+[ext_resource type="Texture2D" path="res://assets/icons/kingdom1/tower_level2.svg" id="4"]
+[ext_resource type="Texture2D" path="res://assets/icons/kingdom1/tower_level3.svg" id="5"]
+[ext_resource type="PackedScene" path="res://assets/models/kingdom1/tower_level1.tscn" id="6"]
+[ext_resource type="PackedScene" path="res://assets/models/kingdom1/tower_level2.tscn" id="7"]
+[ext_resource type="PackedScene" path="res://assets/models/kingdom1/tower_level3.tscn" id="8"]
 
 [sub_resource type="Resource" id="Level1"]
 script = ExtResource("2")
 cost = 220
 icon = ExtResource("3")
-scene = ExtResource("4")
+scene = ExtResource("6")
 
 [sub_resource type="Resource" id="Level2"]
 script = ExtResource("2")
 cost = 520
-icon = ExtResource("3")
-scene = ExtResource("5")
+icon = ExtResource("4")
+scene = ExtResource("7")
 
 [sub_resource type="Resource" id="Level3"]
 script = ExtResource("2")
 cost = 940
-icon = ExtResource("3")
-scene = ExtResource("6")
+icon = ExtResource("5")
+scene = ExtResource("8")
 
 [resource]
 script = ExtResource("1")

--- a/assets/models/kingdom1/home_level1.tscn
+++ b/assets/models/kingdom1/home_level1.tscn
@@ -1,0 +1,28 @@
+[gd_scene load_steps=5 format=3]
+
+[sub_resource type="BoxMesh" id="BoxMesh_body"]
+size = Vector3(4, 2.5, 4)
+
+[sub_resource type="StandardMaterial3D" id="Material_body"]
+albedo_color = Color(0.88, 0.57, 0.36, 1)
+roughness = 0.45
+
+[sub_resource type="BoxMesh" id="BoxMesh_roof"]
+size = Vector3(4.8, 1.6, 4.8)
+
+[sub_resource type="StandardMaterial3D" id="Material_roof"]
+albedo_color = Color(0.57, 0.2, 0.17, 1)
+metallic = 0.05
+
+[node name="HomeLevel1" type="Node3D"]
+
+[node name="Body" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_body")
+material_override = SubResource("Material_body")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.25, 0)
+
+[node name="Roof" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_roof")
+material_override = SubResource("Material_roof")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.8, 0)
+scale = Vector3(1, 0.5, 1)

--- a/assets/models/kingdom1/home_level2.tscn
+++ b/assets/models/kingdom1/home_level2.tscn
@@ -1,0 +1,41 @@
+[gd_scene load_steps=7 format=3]
+
+[sub_resource type="BoxMesh" id="BoxMesh_body"]
+size = Vector3(4.4, 3, 4.4)
+
+[sub_resource type="StandardMaterial3D" id="Material_body"]
+albedo_color = Color(0.82, 0.5, 0.28, 1)
+roughness = 0.4
+
+[sub_resource type="BoxMesh" id="BoxMesh_roof"]
+size = Vector3(5.2, 1.8, 5.2)
+
+[sub_resource type="StandardMaterial3D" id="Material_roof"]
+albedo_color = Color(0.46, 0.16, 0.12, 1)
+metallic = 0.08
+
+[sub_resource type="BoxMesh" id="BoxMesh_chimney"]
+size = Vector3(1, 2.4, 1)
+
+[sub_resource type="StandardMaterial3D" id="Material_chimney"]
+albedo_color = Color(0.55, 0.55, 0.55, 1)
+roughness = 0.6
+
+[node name="HomeLevel2" type="Node3D"]
+
+[node name="Body" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_body")
+material_override = SubResource("Material_body")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.5, 0)
+
+[node name="Roof" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_roof")
+material_override = SubResource("Material_roof")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3.4, 0)
+scale = Vector3(1, 0.45, 1)
+
+[node name="Chimney" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_chimney")
+material_override = SubResource("Material_chimney")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.4, 4.1, -1.1)
+scale = Vector3(0.6, 1, 0.6)

--- a/assets/models/kingdom1/market_level1.tscn
+++ b/assets/models/kingdom1/market_level1.tscn
@@ -1,0 +1,46 @@
+[gd_scene load_steps=7 format=3]
+
+[sub_resource type="BoxMesh" id="BoxMesh_stall"]
+size = Vector3(5, 1, 3.5)
+
+[sub_resource type="StandardMaterial3D" id="Material_stall"]
+albedo_color = Color(0.32, 0.24, 0.18, 1)
+roughness = 0.6
+
+[sub_resource type="BoxMesh" id="BoxMesh_canopy"]
+size = Vector3(5.4, 0.8, 3.9)
+
+[sub_resource type="StandardMaterial3D" id="Material_canopy"]
+albedo_color = Color(0.25, 0.6, 0.3, 1)
+emission_enabled = true
+emission = Color(0.05, 0.18, 0.08, 1)
+
+[sub_resource type="CylinderMesh" id="Mesh_pole"]
+radius = 0.2
+height = 3.2
+
+[sub_resource type="StandardMaterial3D" id="Material_pole"]
+albedo_color = Color(0.68, 0.58, 0.48, 1)
+
+[node name="MarketLevel1" type="Node3D"]
+
+[node name="Stall" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_stall")
+material_override = SubResource("Material_stall")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
+
+[node name="Canopy" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_canopy")
+material_override = SubResource("Material_canopy")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.2, 0)
+scale = Vector3(1, 0.4, 1)
+
+[node name="PoleLeft" type="MeshInstance3D" parent="."]
+mesh = SubResource("Mesh_pole")
+material_override = SubResource("Material_pole")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.2, 1.6, -1.5)
+
+[node name="PoleRight" type="MeshInstance3D" parent="."]
+mesh = SubResource("Mesh_pole")
+material_override = SubResource("Material_pole")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2.2, 1.6, -1.5)

--- a/assets/models/kingdom1/market_level2.tscn
+++ b/assets/models/kingdom1/market_level2.tscn
@@ -1,0 +1,62 @@
+[gd_scene load_steps=9 format=3]
+
+[sub_resource type="BoxMesh" id="BoxMesh_stall"]
+size = Vector3(6, 1.2, 4.5)
+
+[sub_resource type="StandardMaterial3D" id="Material_stall"]
+albedo_color = Color(0.3, 0.22, 0.16, 1)
+roughness = 0.55
+
+[sub_resource type="BoxMesh" id="BoxMesh_canopy"]
+size = Vector3(6.4, 1.1, 5)
+
+[sub_resource type="StandardMaterial3D" id="Material_canopy"]
+albedo_color = Color(0.2, 0.55, 0.45, 1)
+emission_enabled = true
+emission = Color(0.04, 0.18, 0.16, 1)
+
+[sub_resource type="CylinderMesh" id="Mesh_pole"]
+radius = 0.22
+height = 3.8
+
+[sub_resource type="StandardMaterial3D" id="Material_pole"]
+albedo_color = Color(0.7, 0.6, 0.5, 1)
+
+[sub_resource type="BoxMesh" id="Mesh_crate"]
+size = Vector3(1.2, 1.2, 1.2)
+
+[sub_resource type="StandardMaterial3D" id="Material_crate"]
+albedo_color = Color(0.54, 0.39, 0.22, 1)
+
+[node name="MarketLevel2" type="Node3D"]
+
+[node name="Stall" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_stall")
+material_override = SubResource("Material_stall")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.6, 0)
+
+[node name="Canopy" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_canopy")
+material_override = SubResource("Material_canopy")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.6, 0)
+scale = Vector3(1, 0.45, 1)
+
+[node name="PoleLeft" type="MeshInstance3D" parent="."]
+mesh = SubResource("Mesh_pole")
+material_override = SubResource("Material_pole")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.8, 1.9, -1.8)
+
+[node name="PoleRight" type="MeshInstance3D" parent="."]
+mesh = SubResource("Mesh_pole")
+material_override = SubResource("Material_pole")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2.8, 1.9, -1.8)
+
+[node name="CrateA" type="MeshInstance3D" parent="."]
+mesh = SubResource("Mesh_crate")
+material_override = SubResource("Material_crate")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1.8, 0.6, 2)
+
+[node name="CrateB" type="MeshInstance3D" parent="."]
+mesh = SubResource("Mesh_crate")
+material_override = SubResource("Material_crate")
+transform = Transform3D(0.866025, 0, 0.5, 0, 1, 0, -0.5, 0, 0.866025, 1.6, 0.6, 2.3)

--- a/assets/models/kingdom1/tower_level1.tscn
+++ b/assets/models/kingdom1/tower_level1.tscn
@@ -1,0 +1,40 @@
+[gd_scene load_steps=7 format=3]
+
+[sub_resource type="CylinderMesh" id="Mesh_tower_base"]
+radius = 2.2
+height = 6
+
+[sub_resource type="StandardMaterial3D" id="Material_stone"]
+albedo_color = Color(0.64, 0.64, 0.68, 1)
+roughness = 0.7
+
+[sub_resource type="CylinderMesh" id="Mesh_parapet"]
+radius = 2.6
+height = 1.4
+
+[sub_resource type="StandardMaterial3D" id="Material_parapet"]
+albedo_color = Color(0.55, 0.55, 0.6, 1)
+roughness = 0.65
+
+[sub_resource type="BoxMesh" id="Mesh_door"]
+size = Vector3(1.2, 2, 0.4)
+
+[sub_resource type="StandardMaterial3D" id="Material_door"]
+albedo_color = Color(0.33, 0.22, 0.13, 1)
+
+[node name="TowerLevel1" type="Node3D"]
+
+[node name="Base" type="MeshInstance3D" parent="."]
+mesh = SubResource("Mesh_tower_base")
+material_override = SubResource("Material_stone")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3, 0)
+
+[node name="Parapet" type="MeshInstance3D" parent="."]
+mesh = SubResource("Mesh_parapet")
+material_override = SubResource("Material_parapet")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 6.7, 0)
+
+[node name="Door" type="MeshInstance3D" parent="."]
+mesh = SubResource("Mesh_door")
+material_override = SubResource("Material_door")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 2.2)

--- a/assets/models/kingdom1/tower_level2.tscn
+++ b/assets/models/kingdom1/tower_level2.tscn
@@ -1,0 +1,67 @@
+[gd_scene load_steps=9 format=3]
+
+[sub_resource type="CylinderMesh" id="Mesh_tower_base"]
+radius = 2.4
+height = 7.5
+
+[sub_resource type="StandardMaterial3D" id="Material_stone"]
+albedo_color = Color(0.62, 0.62, 0.68, 1)
+roughness = 0.68
+
+[sub_resource type="CylinderMesh" id="Mesh_upper"]
+radius = 2.8
+height = 2.4
+
+[sub_resource type="StandardMaterial3D" id="Material_upper"]
+albedo_color = Color(0.54, 0.54, 0.6, 1)
+roughness = 0.63
+
+[sub_resource type="BoxMesh" id="Mesh_door"]
+size = Vector3(1.2, 2, 0.4)
+
+[sub_resource type="StandardMaterial3D" id="Material_door"]
+albedo_color = Color(0.3, 0.2, 0.12, 1)
+
+[sub_resource type="BoxMesh" id="Mesh_crenel"]
+size = Vector3(1, 1.4, 0.8)
+
+[sub_resource type="StandardMaterial3D" id="Material_crenel"]
+albedo_color = Color(0.48, 0.48, 0.54, 1)
+roughness = 0.6
+
+[node name="TowerLevel2" type="Node3D"]
+
+[node name="Base" type="MeshInstance3D" parent="."]
+mesh = SubResource("Mesh_tower_base")
+material_override = SubResource("Material_stone")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 3.75, 0)
+
+[node name="Upper" type="MeshInstance3D" parent="."]
+mesh = SubResource("Mesh_upper")
+material_override = SubResource("Material_upper")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 8.7, 0)
+
+[node name="Door" type="MeshInstance3D" parent="."]
+mesh = SubResource("Mesh_door")
+material_override = SubResource("Material_door")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 2.4)
+
+[node name="CrenelFront" type="MeshInstance3D" parent="."]
+mesh = SubResource("Mesh_crenel")
+material_override = SubResource("Material_crenel")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 10, 2.6)
+
+[node name="CrenelBack" type="MeshInstance3D" parent="."]
+mesh = SubResource("Mesh_crenel")
+material_override = SubResource("Material_crenel")
+transform = Transform3D(-1, 0, 8.74228e-08, 0, 1, 0, -8.74228e-08, 0, -1, 0, 10, -2.6)
+
+[node name="CrenelLeft" type="MeshInstance3D" parent="."]
+mesh = SubResource("Mesh_crenel")
+material_override = SubResource("Material_crenel")
+transform = Transform3D(0, 0, -1, 0, 1, 0, 1, 0, 0, -2.6, 10, 0)
+
+[node name="CrenelRight" type="MeshInstance3D" parent="."]
+mesh = SubResource("Mesh_crenel")
+material_override = SubResource("Material_crenel")
+transform = Transform3D(0, 0, 1, 0, 1, 0, -1, 0, 0, 2.6, 10, 0)

--- a/assets/models/kingdom1/tower_level3.tscn
+++ b/assets/models/kingdom1/tower_level3.tscn
@@ -1,0 +1,66 @@
+[gd_scene load_steps=10 format=3]
+
+[sub_resource type="CylinderMesh" id="Mesh_tower_base"]
+radius = 2.6
+height = 9.5
+
+[sub_resource type="StandardMaterial3D" id="Material_stone"]
+albedo_color = Color(0.58, 0.58, 0.64, 1)
+roughness = 0.65
+
+[sub_resource type="BoxMesh" id="Mesh_platform"]
+size = Vector3(6, 0.8, 6)
+
+[sub_resource type="StandardMaterial3D" id="Material_platform"]
+albedo_color = Color(0.45, 0.45, 0.5, 1)
+roughness = 0.6
+
+[sub_resource type="BoxMesh" id="Mesh_roof"]
+size = Vector3(4.5, 2.5, 4.5)
+
+[sub_resource type="StandardMaterial3D" id="Material_roof"]
+albedo_color = Color(0.3, 0.33, 0.45, 1)
+roughness = 0.4
+
+[sub_resource type="BoxMesh" id="Mesh_ballista_base"]
+size = Vector3(2.4, 0.4, 2.4)
+
+[sub_resource type="StandardMaterial3D" id="Material_ballista"]
+albedo_color = Color(0.36, 0.25, 0.18, 1)
+roughness = 0.5
+
+[sub_resource type="BoxMesh" id="Mesh_ballista_arm"]
+size = Vector3(0.4, 0.4, 2.6)
+
+[node name="TowerLevel3" type="Node3D"]
+
+[node name="Base" type="MeshInstance3D" parent="."]
+mesh = SubResource("Mesh_tower_base")
+material_override = SubResource("Material_stone")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 4.75, 0)
+
+[node name="Platform" type="MeshInstance3D" parent="."]
+mesh = SubResource("Mesh_platform")
+material_override = SubResource("Material_platform")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 10.5, 0)
+
+[node name="Roof" type="MeshInstance3D" parent="."]
+mesh = SubResource("Mesh_roof")
+material_override = SubResource("Material_roof")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 12.4, 0)
+scale = Vector3(1, 0.6, 1)
+
+[node name="BallistaBase" type="MeshInstance3D" parent="."]
+mesh = SubResource("Mesh_ballista_base")
+material_override = SubResource("Material_ballista")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 11.2, 0)
+
+[node name="BallistaArmLeft" type="MeshInstance3D" parent="BallistaBase"]
+mesh = SubResource("Mesh_ballista_arm")
+material_override = SubResource("Material_ballista")
+transform = Transform3D(0.92388, 0, 0.382683, 0, 1, 0, -0.382683, 0, 0.92388, -1.1, 0.5, 0)
+
+[node name="BallistaArmRight" type="MeshInstance3D" parent="BallistaBase"]
+mesh = SubResource("Mesh_ballista_arm")
+material_override = SubResource("Material_ballista")
+transform = Transform3D(0.92388, 0, -0.382683, 0, 1, 0, 0.382683, 0, 0.92388, 1.1, 0.5, 0)


### PR DESCRIPTION
## Summary
- add hand-authored SVG icons for each kingdom 1 building level
- create lightweight Godot scenes for the home, market, and tower upgrades
- wire the new assets into the kingdom 1 building configs to replace lattice placeholders

## Testing
- not run (Godot editor unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68daa76710e8832d97eb92d0ec52e367