### PR TITLE
Adjust building tile icon sizing

### DIFF
--- a/scenes/ui/BuildingTile.tscn
+++ b/scenes/ui/BuildingTile.tscn
@@ -49,9 +49,9 @@ size_flags_vertical = 3
 
 [node name="Icon" type="TextureRect" parent="Content/IconContainer"]
 layout_mode = 2
-size_flags_horizontal = 3
-size_flags_vertical = 3
-stretch_mode = 4
+size_flags_horizontal = 4
+size_flags_vertical = 4
+stretch_mode = 5
 
 [node name="NameLabel" type="Label" parent="Content"]
 layout_mode = 2


### PR DESCRIPTION
## Summary
- ensure building tile icons keep their natural size
- center icons while preserving aspect ratio within their container

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dadc6b370c832d9bc957ef320d31dc