### PR TITLE
Adjust spawn button layout in building tile

### DIFF
--- a/scenes/ui/BuildingTile.tscn
+++ b/scenes/ui/BuildingTile.tscn
@@ -66,11 +66,12 @@ horizontal_alignment = 1
 vertical_alignment = 1
 
 [node name="SpawnButton" type="TextureButton" parent="Content"]
-custom_minimum_size = Vector2(0, 96)
+custom_minimum_size = Vector2(192, 64)
 layout_mode = 2
-size_flags_horizontal = 3
+size_flags_horizontal = 4
+size_flags_vertical = 4
 texture_normal = ExtResource("2_sg6mu")
-ignore_texture_size = true
+ignore_texture_size = false
 
 [node name="Label" type="Label" parent="Content/SpawnButton"]
 layout_mode = 1


### PR DESCRIPTION
## Summary
- reduce the spawn button's minimum size so it matches the visible texture
- center the button within the tile by using shrink-center size flags
- allow the button to respect its texture dimensions while keeping the label anchored

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dadf73b1f0832d8180059788cdf093