### PR TITLE
Adjust building tile container layout

### DIFF
--- a/scenes/KingdomBase.tscn
+++ b/scenes/KingdomBase.tscn
@@ -22,13 +22,14 @@ texture_pressed = ExtResource("2_h5qp7")
 
 [node name="BuildingTileContainer" type="MarginContainer" parent="UI"]
 anchors_preset = -1
-anchor_top = 0.75
+anchor_left = 0.0
+anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 37.0
-offset_top = -109.0
-offset_right = -27.0
-offset_bottom = -141.0
+offset_left = 24.0
+offset_top = -304.0
+offset_right = -24.0
+offset_bottom = -16.0
 theme_override_constants/margin_left = 24
 theme_override_constants/margin_top = 16
 theme_override_constants/margin_right = 24


### PR DESCRIPTION
## Summary
- stretch the BuildingTileContainer horizontally with left/right anchors and margins
- adjust vertical anchors and offsets to ensure tiles have the intended height and margins

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dae24efc30832d98c871665e678bbd