### PR TITLE
Fix First Kingdom building spawn points

### DIFF
--- a/assets/kingdoms/FirstKingdom/MarketBuilding.tres
+++ b/assets/kingdoms/FirstKingdom/MarketBuilding.tres
@@ -18,5 +18,5 @@ scene = ExtResource("5_vw1wb")
 [resource]
 script = ExtResource("6_ysg1g")
 display_name = "Water Well"
-spawn_point_path = NodePath("SpawnPoints/Home")
+spawn_point_path = NodePath("SpawnPoints/Market")
 levels = Array[ExtResource("1_0447f")]([SubResource("Level1"), SubResource("Level2")])

--- a/assets/kingdoms/FirstKingdom/TowerBuilding.tres
+++ b/assets/kingdoms/FirstKingdom/TowerBuilding.tres
@@ -20,5 +20,5 @@ metadata/_custom_type_script = "uid://blcm4k05x3wip"
 [resource]
 script = ExtResource("6_kev1n")
 display_name = "Tower"
-spawn_point_path = NodePath("SpawnPoints/Home")
+spawn_point_path = NodePath("SpawnPoints/Tower")
 levels = Array[ExtResource("1_x14uc")]([SubResource("Resource_x14uc"), SubResource("Resource_mqixc")])


### PR DESCRIPTION
## Summary
- point the First Kingdom market building config to its dedicated market spawn point
- point the First Kingdom tower building config to its dedicated tower spawn point
- confirm the remaining building configs still target the correct spawn nodes in the environment scene

## Testing
- not run (Godot editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc2819bf28832d9709ab4569771500