### PR TITLE
Refine building tile cost display

### DIFF
--- a/scenes/ui/BuildingTile.gd
+++ b/scenes/ui/BuildingTile.gd
@@ -2,9 +2,9 @@ extends Control
 
 @onready var icon_rect: TextureRect = $Content/IconContainer/Icon
 @onready var name_label: Label = $Content/NameLabel
-@onready var cost_label: Label = $Content/CostLabel
+@onready var cost_label: Label = $Content/SpawnButton/CostContainer/CostLabel
+@onready var coin_icon: TextureRect = $Content/SpawnButton/CostContainer/CoinIcon
 @onready var spawn_button: TextureButton = $Content/SpawnButton
-@onready var spawn_label: Label = $Content/SpawnButton/Label
 
 var building_config: BuildingConfig
 var environment_root: Node
@@ -75,21 +75,19 @@ func _update_ui() -> void:
 	if name_label:
 		name_label.text = building_config.display_name if building_config else ""
 
-	if cost_label:
-		if next_level:
-			cost_label.text = "Cost: %d" % next_level.cost
-		elif building_config:
-			cost_label.text = "Max level reached"
-		else:
-			cost_label.text = ""
-
-	if spawn_label:
-		if next_level:
-			spawn_label.text = "Build" if active_level_index < 0 else "Upgrade"
-		elif building_config:
-			spawn_label.text = "Max Level"
-		else:
-			spawn_label.text = ""
+        if cost_label:
+                if next_level:
+                        cost_label.text = String.num_int64(next_level.cost)
+                        if coin_icon:
+                                coin_icon.visible = true
+                elif building_config:
+                        cost_label.text = "Max"
+                        if coin_icon:
+                                coin_icon.visible = false
+                else:
+                        cost_label.text = ""
+                        if coin_icon:
+                                coin_icon.visible = false
 
 	if spawn_button:
 		spawn_button.disabled = not _can_spawn()

--- a/scenes/ui/BuildingTile.tscn
+++ b/scenes/ui/BuildingTile.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4 format=3 uid="uid://ci7p6xyvrqxxe"]
+[gd_scene load_steps=5 format=3 uid="uid://ci7p6xyvrqxxe"]
 
 [ext_resource type="Texture2D" uid="uid://bdboum11konu3" path="res://assets/ui/buildings/building_tile.png" id="1_fr0tu"]
 [ext_resource type="Texture2D" uid="uid://cbf5sq8llhhse" path="res://assets/ui/buildings/building_tile_button.png" id="2_sg6mu"]
 [ext_resource type="Script" uid="uid://ccjnacmftx4t5" path="res://scenes/ui/BuildingTile.gd" id="3_g7g2i"]
+[ext_resource type="Texture2D" uid="uid://bl61y1bu44cjo" path="res://assets/icons/coin.png" id="4_2dimu"]
 
 [node name="BuildingTile" type="Control"]
 custom_minimum_size = Vector2(256, 256)
@@ -61,12 +62,6 @@ size_flags_horizontal = 3
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="CostLabel" type="Label" parent="Content"]
-layout_mode = 2
-size_flags_horizontal = 3
-horizontal_alignment = 1
-vertical_alignment = 1
-
 [node name="SpawnButton" type="TextureButton" parent="Content"]
 custom_minimum_size = Vector2(192, 64)
 layout_mode = 2
@@ -76,7 +71,7 @@ texture_normal = ExtResource("2_sg6mu")
 ignore_texture_size = true
 stretch_mode = 0
 
-[node name="Label" type="Label" parent="Content/SpawnButton"]
+[node name="CostContainer" type="HBoxContainer" parent="Content/SpawnButton"]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -87,5 +82,19 @@ offset_right = -9.24039
 offset_bottom = -1.34172
 grow_horizontal = 2
 grow_vertical = 2
+alignment = 1
+size_flags_horizontal = 4
+size_flags_vertical = 4
+theme_override_constants/separation = 8
+
+[node name="CoinIcon" type="TextureRect" parent="Content/SpawnButton/CostContainer"]
+layout_mode = 2
+size_flags_vertical = 4
+texture = ExtResource("4_2dimu")
+stretch_mode = 5
+
+[node name="CostLabel" type="Label" parent="Content/SpawnButton/CostContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
 horizontal_alignment = 1
 vertical_alignment = 1


### PR DESCRIPTION
## Summary
- embed the cost display inside the building spawn button with a coin icon and label
- update the building tile script to manage the new cost layout and show a max-state fallback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd7f498e58832dacc70c63959e277a