### PR TITLE
Add level progress icons to building tile UI

### DIFF
--- a/scenes/ui/BuildingTile.tscn
+++ b/scenes/ui/BuildingTile.tscn
@@ -62,6 +62,13 @@ size_flags_horizontal = 3
 horizontal_alignment = 1
 vertical_alignment = 1
 
+[node name="LevelIcons" type="HBoxContainer" parent="Content"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+theme_override_constants/separation = 6
+alignment = 1
+
 [node name="SpawnButton" type="TextureButton" parent="Content"]
 custom_minimum_size = Vector2(110, 50)
 layout_mode = 2


### PR DESCRIPTION
## Summary
- add a level progress icon row to the building tile scene above the spawn button
- preload build/reward icons and populate the level row whenever the UI refreshes
- visually distinguish completed and upcoming levels to show current progress

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de0defe1f0832d812fc30cdebe6439