### PR TITLE
Fix BuildingTile layout sizing

### DIFF
--- a/scenes/ui/BuildingTile.tscn
+++ b/scenes/ui/BuildingTile.tscn
@@ -9,12 +9,10 @@
 custom_minimum_size = Vector2(256, 256)
 layout_mode = 3
 anchors_preset = 0
-offset_left = -1.0
-offset_top = 3.0
-offset_right = 255.0
-offset_bottom = 259.0
-size_flags_horizontal = 3
-size_flags_vertical = 3
+offset_right = 256.0
+offset_bottom = 256.0
+size_flags_horizontal = 4
+size_flags_vertical = 4
 script = ExtResource("3_g7g2i")
 
 [node name="Background" type="TextureRect" parent="."]
@@ -22,10 +20,10 @@ layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 1.0
-offset_top = -1.0
-offset_right = 1.0
-offset_bottom = 153.26
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 0.0
+offset_bottom = 0.0
 grow_horizontal = 2
 grow_vertical = 2
 texture = ExtResource("1_fr0tu")
@@ -37,15 +35,14 @@ layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 65.0
-offset_top = 216.0
-offset_right = 17.0
-offset_bottom = 168.0
+offset_left = 24.0
+offset_top = 24.0
+offset_right = -24.0
+offset_bottom = -24.0
 grow_horizontal = 2
 grow_vertical = 2
-scale = Vector2(0.593547, 0.269498)
-size_flags_horizontal = 3
-size_flags_vertical = 3
+size_flags_horizontal = 1
+size_flags_vertical = 1
 theme_override_constants/separation = 12
 
 [node name="IconContainer" type="CenterContainer" parent="Content"]
@@ -68,12 +65,14 @@ theme_override_constants/separation = 6
 alignment = 1
 
 [node name="TextureButton" type="TextureButton" parent="."]
-layout_mode = 0
-offset_left = 46.0
-offset_top = 296.0
-offset_right = 598.0
-offset_bottom = 553.0
-scale = Vector2(0.302478, 0.302478)
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 0.0
+offset_bottom = 0.0
 texture_normal = ExtResource("2_sg6mu")
 
 [node name="CostContainer" type="HBoxContainer" parent="TextureButton"]
@@ -81,15 +80,14 @@ layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 46.2843
-offset_top = 3.30598
-offset_right = 72.2842
-offset_bottom = 192.306
+offset_left = 24.0
+offset_top = 180.0
+offset_right = -24.0
+offset_bottom = -24.0
 grow_horizontal = 2
 grow_vertical = 2
-scale = Vector2(0.556723, 0.556723)
-size_flags_horizontal = 4
-size_flags_vertical = 4
+size_flags_horizontal = 1
+size_flags_vertical = 1
 theme_override_constants/separation = 8
 alignment = 1
 


### PR DESCRIPTION
## Summary
- ensure the BuildingTile control keeps its custom minimum size by using shrink-center size flags
- reset child anchors and margins so the tile layout remains consistent in the kingdom view

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0bcac4070832da5669745d6a34965