### PR TITLE
Add draw counter UI and attack overlay handling

### DIFF
--- a/scenes/PhysicsTable.tscn
+++ b/scenes/PhysicsTable.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=18 format=3 uid="uid://durc7b7iguq8j"]
+[gd_scene load_steps=19 format=3 uid="uid://durc7b7iguq8j"]
 
 [ext_resource type="Texture2D" uid="uid://b4g3082mkfsxo" path="res://assets/cards_png/gpt_game_assets/background_2.png" id="1"]
 [ext_resource type="Script" uid="uid://wvect22etct2" path="res://scripts/PhysicsDeckManager.gd" id="2"]
@@ -11,6 +11,7 @@
 [ext_resource type="Texture2D" uid="uid://16ruswnnpyla" path="res://assets/ui/bars/progres bar_overlay_wooden.png" id="9_mzh22"]
 [ext_resource type="Texture2D" uid="uid://brb1yke7h151h" path="res://assets/ui/buttons/build.png" id="10_hp780"]
 [ext_resource type="Texture2D" uid="uid://drcpd0a3cupvf" path="res://assets/ui/buttons/build_pressed.png" id="11_0sh32"]
+[ext_resource type="Texture2D" path="res://assets/ui/draws.png" id="12_0d1rg"]
 
 [sub_resource type="PhysicsMaterial" id="1"]
 friction = 0.2
@@ -150,6 +151,57 @@ offset_bottom = 1492.0
 scale = Vector2(0.15, 0.15)
 texture_normal = ExtResource("10_hp780")
 texture_pressed = ExtResource("11_0sh32")
+
+[node name="DrawsContainer" type="HBoxContainer" parent="UI"]
+anchors_preset = 1
+offset_left = 24.0
+offset_top = 24.0
+offset_right = 224.0
+offset_bottom = 74.0
+grow_horizontal = 0
+grow_vertical = 0
+alignment = 1
+
+[node name="DrawsIcon" type="TextureRect" parent="UI/DrawsContainer"]
+custom_minimum_size = Vector2(40, 40)
+texture = ExtResource("12_0d1rg")
+stretch_mode = 4
+
+[node name="DrawsLabel" type="Label" parent="UI/DrawsContainer"]
+theme = SubResource("Theme_teiip")
+theme_override_colors/font_color = Color(0.832235, 0.713053, 0.620879, 1)
+theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
+text = "Draws: 100"
+vertical_alignment = 1
+
+[node name="AttackOverlay" type="ColorRect" parent="UI"]
+visible = false
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0, 0, 0, 0.6)
+
+[node name="AttackLabel" type="Label" parent="UI/AttackOverlay"]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -150.0
+offset_top = -40.0
+offset_right = 150.0
+offset_bottom = 40.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = SubResource("Theme_teiip")
+theme_override_colors/font_color = Color(1, 0.239216, 0.239216, 1)
+theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
+text = "ATTACK!"
+horizontal_alignment = 1
+vertical_alignment = 1
+scale = Vector2(2, 2)
 
 [node name="WorldEnvironment" type="WorldEnvironment" parent="."]
 environment = SubResource("Environment_i431q")

--- a/scripts/PhysicsDeckManager.gd
+++ b/scripts/PhysicsDeckManager.gd
@@ -29,6 +29,8 @@ const SCATTER_SPEED := 12.0
 @onready var score_label: Label = $UI/ScoreLabel
 @onready var score_bar: TextureProgressBar = $UI/ScoreBar
 @onready var total_score_label: Label = $UI/TotalScoreLabel
+@onready var draws_label: Label = $UI/DrawsContainer/DrawsLabel
+@onready var attack_overlay: ColorRect = $UI/AttackOverlay
 
 # Runtime
 var cards: Array[RigidBody3D] = []
@@ -40,6 +42,7 @@ var card_count := 0
 var round_score := 0
 var total_score := 0
 var displayed_score := 0
+var draws_remaining := 100
 
 var score_update_queue: Array[int] = []
 var processing_scores := false
@@ -47,12 +50,13 @@ var is_dealing := false
 var is_animating := false
 
 func _ready() -> void:
-	randomize()
-	score_bar.step = 0
-	score_bar.max_value = 21
-	displayed_score = 0
-	_wire_ui()
-	_start_round()
+        randomize()
+        score_bar.step = 0
+        score_bar.max_value = 21
+        displayed_score = 0
+        _wire_ui()
+        _refresh_draws_ui()
+        _start_round()
 	
 func _wire_ui() -> void:
 	if draw_button and not draw_button.pressed.is_connected(_on_draw_pressed):
@@ -63,18 +67,22 @@ func _wire_ui() -> void:
 		build_button.pressed.connect(_on_build_pressed)
 
 func _start_round() -> void:
-	is_dealing = false
-	is_animating = false
-	jackpot_card = null
-	last_dealt_card = null
-	last_fall_time = 0.0
-	_enable_inputs(true, false)
+        is_dealing = false
+        is_animating = false
+        jackpot_card = null
+        last_dealt_card = null
+        last_fall_time = 0.0
+        _refresh_draws_ui()
+        _enable_inputs(true, false)
 
 func _enable_inputs(draw: bool, hold: bool) -> void:
-	if draw_button:
-		draw_button.disabled = not draw or is_dealing or is_animating
-	if hold_button:
-		hold_button.disabled = not hold or is_dealing or is_animating
+        var can_draw := draw and draws_remaining > 0 and not is_dealing and not is_animating
+        var can_hold := hold and not is_dealing and not is_animating
+        if draw_button:
+                draw_button.disabled = not can_draw
+        if hold_button:
+                hold_button.disabled = not can_hold
+        _refresh_draws_ui()
 	
 	
 func _lock_inputs() -> void:
@@ -392,11 +400,19 @@ func _jiggle_progress_bar() -> void:
 # UI events
 
 func _on_draw_pressed() -> void:
-	if is_dealing or is_animating:
-		return
-	_lock_inputs()
-	await _auto_draw_round()
-	await _evaluate_round()
+        if is_dealing or is_animating or draws_remaining <= 0:
+                return
+        draws_remaining = max(draws_remaining - 1, 0)
+        _refresh_draws_ui()
+        _lock_inputs()
+        await _auto_draw_round()
+        await _evaluate_round()
+
+func _refresh_draws_ui() -> void:
+        if draws_label:
+                draws_label.text = "Draws: %d" % max(draws_remaining, 0)
+        if attack_overlay:
+                attack_overlay.visible = draws_remaining <= 0
 
 func _on_hold_pressed() -> void:
 	if is_dealing or is_animating:


### PR DESCRIPTION
## Summary
- add a draw counter widget and attack overlay to the physics table UI
- track remaining draws in the deck manager and update the UI/controls accordingly
- prevent drawing when out of stock and surface the attack overlay when the limit is reached

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2276b9738832dad395dd02cf6f5b1