### PR TITLE
Adjust total score layout

### DIFF
--- a/scenes/PhysicsTable.tscn
+++ b/scenes/PhysicsTable.tscn
@@ -105,36 +105,37 @@ texture_under = ExtResource("7_lqfcu")
 texture_over = ExtResource("9_mzh22")
 texture_progress = ExtResource("8_zd8al")
 
-[node name="TotalScoreIcon" type="TextureRect" parent="UI"]
+[node name="TotalScoreContainer" type="HBoxContainer" parent="UI"]
 anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = -84.0
-offset_top = -304.0
-offset_right = -44.0
-offset_bottom = -264.0
+offset_left = -90.0
+offset_top = -308.0
+offset_right = 90.0
+offset_bottom = -260.0
 grow_horizontal = 2
 grow_vertical = 2
+alignment = 1
+size_flags_horizontal = 4
+size_flags_vertical = 0
+theme = SubResource("Theme_teiip")
+
+[node name="TotalScoreIcon" type="TextureRect" parent="UI/TotalScoreContainer"]
+custom_minimum_size = Vector2(40, 40)
+grow_horizontal = 0
+grow_vertical = 0
+size_flags_horizontal = 0
+size_flags_vertical = 4
 scale = Vector2(0.35, 0.35)
 texture = ExtResource("13_7s1k7")
 stretch_mode = 5
 
-[node name="TotalScoreLabel" type="Label" parent="UI"]
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -16.0
-offset_top = -299.0
-offset_right = 58.0
-offset_bottom = -269.0
+[node name="TotalScoreLabel" type="Label" parent="UI/TotalScoreContainer"]
 grow_horizontal = 2
 grow_vertical = 2
 scale = Vector2(2, 2)
-theme = SubResource("Theme_teiip")
 theme_override_colors/font_color = Color(0.832235, 0.713053, 0.620879, 1)
 theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
 text = "0"

--- a/scripts/PhysicsDeckManager.gd
+++ b/scripts/PhysicsDeckManager.gd
@@ -28,7 +28,7 @@ const SCATTER_SPEED := 12.0
 @onready var build_button: TextureButton = $UI/BuildButton
 @onready var score_label: Label = $UI/ScoreLabel
 @onready var score_bar: TextureProgressBar = $UI/ScoreBar
-@onready var total_score_label: Label = $UI/TotalScoreLabel
+@onready var total_score_label: Label = $UI/TotalScoreContainer/TotalScoreLabel
 @onready var draws_label: Label = $UI/DrawsContainer/DrawsLabel
 @onready var attack_overlay: ColorRect = $UI/AttackOverlay
 


### PR DESCRIPTION
## Summary
- wrap the total score icon and label in an HBoxContainer so the text no longer overlaps the coin
- update the deck manager to use the new total score label path

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5fe1dc740832dbe2efbb3069c1b12