### PR TITLE
Fix PhysicsTable UI merge conflict

### DIFF
--- a/scenes/PhysicsTable.tscn
+++ b/scenes/PhysicsTable.tscn
@@ -111,17 +111,10 @@ anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-<<<<<<< HEAD
-offset_left = -61.0
-offset_top = -309.0
-offset_right = 167.0
-offset_bottom = -83.0
-=======
 offset_left = -90.0
 offset_top = -308.0
 offset_right = 90.0
 offset_bottom = -260.0
->>>>>>> 6a2901714452172fe3b7bbf5de23021d7ae1d55a
 grow_horizontal = 2
 grow_vertical = 2
 alignment = 1
@@ -131,6 +124,7 @@ theme = SubResource("Theme_teiip")
 
 [node name="TotalScoreIcon" type="TextureRect" parent="UI/TotalScoreContainer"]
 custom_minimum_size = Vector2(40, 40)
+layout_mode = 2
 grow_horizontal = 0
 grow_vertical = 0
 size_flags_horizontal = 0
@@ -139,20 +133,8 @@ scale = Vector2(0.35, 0.35)
 texture = ExtResource("13_7s1k7")
 stretch_mode = 5
 
-<<<<<<< HEAD
-[node name="TotalScoreLabel" type="Label" parent="UI"]
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = 24.0
-offset_top = -299.0
-offset_right = 98.0
-offset_bottom = -269.0
-=======
 [node name="TotalScoreLabel" type="Label" parent="UI/TotalScoreContainer"]
->>>>>>> 6a2901714452172fe3b7bbf5de23021d7ae1d55a
+layout_mode = 2
 grow_horizontal = 2
 grow_vertical = 2
 scale = Vector2(2, 2)


### PR DESCRIPTION
## Summary
- resolve merge conflict artifacts in PhysicsTable.tscn
- ensure the total score label lives inside the TotalScoreContainer with proper layout settings

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5ffd25bd8832db41cdeafd0738658